### PR TITLE
21 change base css location in react UI

### DIFF
--- a/packages/react-ui/components.json
+++ b/packages/react-ui/components.json
@@ -5,7 +5,7 @@
   "tsx": true,
   "tailwind": {
     "config": "",
-    "css": "src/index.css",
+    "css": "src/styles/base.css",
     "baseColor": "neutral",
     "cssVariables": true,
     "prefix": ""

--- a/packages/react-ui/src/base/shadcn-ui/index.ts
+++ b/packages/react-ui/src/base/shadcn-ui/index.ts
@@ -1,6 +1,3 @@
-/* base 스타일 */
-import "@/styles/base.css";
-
 /* Button 컴포넌트 */
 export { buttonVariants } from "@/base/shadcn-ui/buttonVariants";
 export { Button } from "@/base/shadcn-ui/button";

--- a/packages/react-ui/src/styles/index.ts
+++ b/packages/react-ui/src/styles/index.ts
@@ -1,0 +1,2 @@
+/* base 스타일 */
+import "@/styles/base.css";

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -23,6 +23,8 @@ const fileName: Exclude<LibraryOptions["fileName"], string> = (
       return `lib/utils.${format}.js`;
     case "components":
       return `components/index.${format}.js`;
+    case "styles":
+      return `styles/index.${format}.js`;
     default:
       return `${entryName}/index.${format}.js`;
   }
@@ -38,6 +40,7 @@ export default defineConfig({
         "shadcn-ui": resolve(__dirname, "src/base/shadcn-ui/index.ts"),
         utils: resolve(__dirname, "src/lib/utils.ts"),
         components: resolve(__dirname, "src/components/index.ts"),
+        styles: resolve(__dirname, "src/styles/index.ts"),
       },
       formats: ["es", "cjs"],
       fileName,


### PR DESCRIPTION
This pull request includes several changes to the `packages/react-ui` directory to improve the structure and organization of styles and components. The most important changes include updating the Tailwind CSS configuration, modifying the import paths for base styles, and updating the Vite configuration to include styles.

Updates to Tailwind CSS configuration:

* [`packages/react-ui/components.json`](diffhunk://#diff-d175c6c0ff7feb22bdee73c14355a24b66f7c7f54d27050a1a8746777186f6f6L8-R8): Changed the CSS path from `src/index.css` to `src/styles/base.css`.

Modifications to import paths for base styles:

* [`packages/react-ui/src/base/shadcn-ui/index.ts`](diffhunk://#diff-39ddd8248e8fcc43b30bcb30430db1b4737a8a6eb2586eaf8e4a279f74a2528cL1-L3): Removed the import statement for `base.css` from this file.
* [`packages/react-ui/src/styles/index.ts`](diffhunk://#diff-08c8cb9957e2a050329771cfc7a0d6939fe7b6762cd689452064ef5448b0364eR1-R2): Added an import statement for `base.css` to this file.

Updates to Vite configuration:

* [`packages/react-ui/vite.config.ts`](diffhunk://#diff-dfbb5d5ec1e5080d16287cdcd9f7e7034558fa092ca661ce988baf58d6ee0d79R26-R27): Added a new case for "styles" in the `fileName` function to return the appropriate path for styles.
* [`packages/react-ui/vite.config.ts`](diffhunk://#diff-dfbb5d5ec1e5080d16287cdcd9f7e7034558fa092ca661ce988baf58d6ee0d79R43): Added a new alias for "styles" in the Vite configuration.