### PR TITLE
react-ui 패키지에서 vite 빌드 시 기존 dist 산출물 디렉토리를 제거하지 않도록 설정 변경

### DIFF
--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -34,6 +34,7 @@ const fileName: Exclude<LibraryOptions["fileName"], string> = (
 export default defineConfig({
   plugins: [dtsPlugin(), react(), tsConfigPaths(), tailwindcss()],
   build: {
+    emptyOutDir: false,
     lib: {
       name: "react-ui",
       entry: {


### PR DESCRIPTION
This pull request includes a change to the `packages/react-ui/vite.config.ts` file to improve the build configuration.

Build configuration improvement:

* [`packages/react-ui/vite.config.ts`](diffhunk://#diff-dfbb5d5ec1e5080d16287cdcd9f7e7034558fa092ca661ce988baf58d6ee0d79R37): Set `emptyOutDir` to `false` in the build configuration to prevent the output directory from being cleared before each build.