### PR TITLE
`browser-utils` 및 `react-utils` 패키지에 브라우저 환경에서 사용할 `msw` 워커 셋업 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 
 # IDE
 .idea
+
+# MSW
+mockServiceWorker.js

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import { USE_MSW } from "../configs/mocks";
 import "./globals.css";
+import ApplyMSW from "../containers/ApplyMSW";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -24,7 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        {children}
+        {!USE_MSW ? children : <ApplyMSW>{children}</ApplyMSW>}
       </body>
     </html>
   );

--- a/apps/web/configs/mocks.ts
+++ b/apps/web/configs/mocks.ts
@@ -1,0 +1,22 @@
+import { type ComponentProps } from "react";
+import { type MSWProvider } from "@repo/react-utils/providers";
+
+/**
+ * This is used to configure the mock service worker (MSW)
+ * for development and testing purposes.
+ */
+export const USE_MSW = process.env.NODE_ENV !== "production";
+
+/**
+ * This is used to configure the start options for the mock service worker (MSW).
+ */
+export const MSW_START_OPTIONS: ComponentProps<
+  typeof MSWProvider
+>["startOptions"] = {
+  onUnhandledRequest(request, print) {
+    if (request.url.includes("_next")) {
+      return;
+    }
+    print.warning();
+  },
+};

--- a/apps/web/containers/ApplyMSW/index.tsx
+++ b/apps/web/containers/ApplyMSW/index.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import type { FC, PropsWithChildren } from "react";
+import { MSWProvider } from "@repo/react-utils/providers";
+import rootHandlers from "@repo/http-clients/mocks";
+import { MSW_START_OPTIONS } from "../../configs/mocks";
+
+const ApplyMSW: FC<PropsWithChildren> = ({ children }) => {
+  return (
+    <MSWProvider handlers={rootHandlers} startOptions={MSW_START_OPTIONS}>
+      {children}
+    </MSWProvider>
+  );
+};
+export default ApplyMSW;

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -20,6 +20,11 @@
       "types": "./dist/dom/index.d.ts",
       "import": "./dist/dom/index.es.js",
       "require": "./dist/dom/index.cjs.js"
+    },
+    "./msw": {
+      "types": "./dist/msw/index.d.ts",
+      "import": "./dist/msw/index.es.js",
+      "require": "./dist/msw/index.cjs.js"
     }
   },
   "files": [

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -35,6 +35,9 @@
     "vite-plugin-dts": "^4.5.3",
     "vite-tsconfig-paths": "^5.1.4"
   },
+  "dependencies": {
+    "msw": "^2.7.3"
+  },
   "engines": {
     "node": ">=22"
   }

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint . --max-warnings 0",
     "check-types": "tsc --noEmit",
-    "dev": "tsc && vite build --watch",
+    "dev": "pnpm dlx msw init && tsc && vite build --watch",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },
@@ -40,5 +40,10 @@
   },
   "engines": {
     "node": ">=22"
+  },
+  "msw": {
+    "workerDirectory": [
+      "../../apps/web/public"
+    ]
   }
 }

--- a/packages/browser-utils/src/msw/index.ts
+++ b/packages/browser-utils/src/msw/index.ts
@@ -1,0 +1,1 @@
+export { default as initMockWorker } from "./initMockWorker";

--- a/packages/browser-utils/src/msw/initMockWorker/index.ts
+++ b/packages/browser-utils/src/msw/initMockWorker/index.ts
@@ -1,0 +1,25 @@
+import type { HttpHandler } from "msw";
+import type { StartOptions } from "msw/browser";
+
+/**
+ * Initializes the mock worker for testing purposes.
+ *
+ * @param handlers - An array of request handlers to be used by the worker.
+ * @param options - Optional configuration options for the worker.
+ */
+const initMockWorker = async (
+  handlers: HttpHandler[],
+  options?: StartOptions,
+) => {
+  // This code is only executed in the browser
+  const isBrowser = typeof window !== "undefined";
+  if (!isBrowser) return;
+
+  // Import the setupWorker function from the msw/browser package
+  const { setupWorker } = await import("msw/browser");
+
+  // This configures a request mocking worker with the given request handlers.
+  const mockWorker = setupWorker(...handlers);
+  await mockWorker.start(options);
+};
+export default initMockWorker;

--- a/packages/browser-utils/vite.config.ts
+++ b/packages/browser-utils/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       entry: {
         string: resolve(__dirname, "src/string/index.ts"),
         dom: resolve(__dirname, "src/dom/index.ts"),
+        msw: resolve(__dirname, "src/msw/index.ts"),
       },
       formats: ["es", "cjs"],
       fileName: (format, entryName) => `${entryName}/index.${format}.js`,

--- a/packages/react-utils/package.json
+++ b/packages/react-utils/package.json
@@ -29,6 +29,9 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
+  "dependencies": {
+    "@repo/browser-utils": "workspace:*"
+  },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",

--- a/packages/react-utils/package.json
+++ b/packages/react-utils/package.json
@@ -20,6 +20,11 @@
       "types": "./dist/hocs/index.d.ts",
       "import": "./dist/hocs/index.es.js",
       "require": "./dist/hocs/index.cjs.js"
+    },
+    "./providers": {
+      "types": "./dist/providers/index.d.ts",
+      "import": "./dist/providers/index.es.js",
+      "require": "./dist/providers/index.cjs.js"
     }
   },
   "files": [

--- a/packages/react-utils/package.json
+++ b/packages/react-utils/package.json
@@ -46,6 +46,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "rollup-preserve-directives": "^1.1.3",
     "eslint": "^9.23.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "typescript": "5.8.2",

--- a/packages/react-utils/src/providers/MSWProvider/index.tsx
+++ b/packages/react-utils/src/providers/MSWProvider/index.tsx
@@ -32,8 +32,8 @@ const MSWProvider: FC<PropsWithChildren<Props>> = ({
         try {
           await initMockWorker(handlers, startOptions);
           setInitialized(true);
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (error) {
+          console.error("Failed to initialize mock worker:", error);
           setInitialized(false);
         }
       })();

--- a/packages/react-utils/src/providers/MSWProvider/index.tsx
+++ b/packages/react-utils/src/providers/MSWProvider/index.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { type FC, type PropsWithChildren, useEffect, useState } from "react";
+import { initMockWorker } from "@repo/browser-utils/msw";
+
+interface Props {
+  // The request handlers to be used by the mock worker.
+  handlers: Parameters<typeof initMockWorker>[0];
+  // The options to start the mock worker.
+  startOptions?: Parameters<typeof initMockWorker>[1];
+}
+
+/**
+ * This component is used to provide the MSW context to the child components.
+ *
+ * @param children - The child components to be rendered.
+ * @param handlers - The request handlers to be used by the mock worker.
+ * @param startOptions - The options to start the mock worker.
+ */
+const MSWProvider: FC<PropsWithChildren<Props>> = ({
+  children,
+  handlers,
+  startOptions,
+}) => {
+  // State to track the initialization of the mock worker.
+  const [initialized, setInitialized] = useState(false);
+
+  // If the mock worker is not initialized, register it.
+  useEffect(
+    function registerMockWorker() {
+      (async function initializeMockWorker() {
+        try {
+          await initMockWorker(handlers, startOptions);
+          setInitialized(true);
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        } catch (error) {
+          setInitialized(false);
+        }
+      })();
+    },
+    [handlers, startOptions],
+  );
+
+  // If the mock worker is not initialized, return null to avoid rendering the children.
+  if (!initialized) return null;
+
+  // If the mock worker is initialized, render the children.
+  return children;
+};
+export default MSWProvider;

--- a/packages/react-utils/src/providers/index.ts
+++ b/packages/react-utils/src/providers/index.ts
@@ -1,0 +1,1 @@
+export { default as MSWProvider } from "./MSWProvider";

--- a/packages/react-utils/vite.config.ts
+++ b/packages/react-utils/vite.config.ts
@@ -3,10 +3,11 @@ import { resolve } from "path";
 import react from "@vitejs/plugin-react";
 import dtsPlugin from "vite-plugin-dts";
 import tsConfigPaths from "vite-tsconfig-paths";
+import { preserveDirective } from "rollup-preserve-directives";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [dtsPlugin(), react(), tsConfigPaths()],
+  plugins: [dtsPlugin(), react(), tsConfigPaths(), preserveDirective()],
   build: {
     lib: {
       name: "react-utils",

--- a/packages/react-utils/vite.config.ts
+++ b/packages/react-utils/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       entry: {
         hooks: resolve(__dirname, "src/hooks/index.ts"),
         hocs: resolve(__dirname, "src/hocs/index.ts"),
+        providers: resolve(__dirname, "src/providers/index.ts"),
       },
       formats: ["es", "cjs"],
       fileName: (format, entryName) => `${entryName}/index.${format}.js`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,6 +414,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      rollup-preserve-directives:
+        specifier: ^1.1.3
+        version: 1.1.3(rollup@4.39.0)
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -3790,6 +3793,11 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
+
+  rollup-preserve-directives@1.1.3:
+    resolution: {integrity: sha512-oXqxd6ZzkoQej8Qt0k+S/yvO2+S4CEVEVv2g85oL15o0cjAKTKEuo2MzyA8FcsBBXbtytBzBMFAbhvQg4YyPUQ==}
+    peerDependencies:
+      rollup: ^2.0.0 || ^3.0.0 || ^4.0.0
 
   rollup@4.39.0:
     resolution: {integrity: sha512-thI8kNc02yNvnmJp8dr3fNWJ9tCONDhp6TV35X6HkKGGs9E6q7YWCHbe5vKiTa7TAiNcFEmXKj3X/pG2b3ci0g==}
@@ -8267,6 +8275,11 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rollup-preserve-directives@1.1.3(rollup@4.39.0):
+    dependencies:
+      magic-string: 0.30.17
+      rollup: 4.39.0
 
   rollup@4.39.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,6 +379,10 @@ importers:
         version: 5.1.4(typescript@5.8.2)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))
 
   packages/react-utils:
+    dependencies:
+      '@repo/browser-utils':
+        specifier: workspace:*
+        version: link:../browser-utils
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,10 @@ importers:
         version: 5.8.2
 
   packages/browser-utils:
+    dependencies:
+      msw:
+        specifier: ^2.7.3
+        version: 2.7.3(@types/node@22.13.10)(typescript@5.8.2)
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*

--- a/turbo.json
+++ b/turbo.json
@@ -18,5 +18,6 @@
       "cache": false,
       "persistent": true
     }
-  }
+  },
+  "globalEnv": ["NODE_ENV"]
 }


### PR DESCRIPTION
This pull request introduces the integration of Mock Service Worker (MSW) for development and testing purposes across multiple packages. The changes include configuring MSW, adding necessary dependencies, and updating configurations to support the new functionality.

### MSW Integration:

* [`apps/web/app/layout.tsx`](diffhunk://#diff-c235c52626fe2cfbb53241bb015bdd7b5f5a28f9a10a08e1f401238e773fa7adR3-R5): Imported `USE_MSW` and `ApplyMSW` to conditionally wrap the application layout with MSW provider based on the environment. [[1]](diffhunk://#diff-c235c52626fe2cfbb53241bb015bdd7b5f5a28f9a10a08e1f401238e773fa7adR3-R5) [[2]](diffhunk://#diff-c235c52626fe2cfbb53241bb015bdd7b5f5a28f9a10a08e1f401238e773fa7adL27-R29)
* [`apps/web/configs/mocks.ts`](diffhunk://#diff-744681458310e034a42175f21f1d1da0519ea0931710a0d913d7510a7501ac0dR1-R22): Added configuration for MSW including `USE_MSW` and `MSW_START_OPTIONS`.
* [`apps/web/containers/ApplyMSW/index.tsx`](diffhunk://#diff-dc40e17e12351a2a3e0ef0a66ddabb29a2189a411bbe6a232f39513852bc8f8cR1-R15): Created `ApplyMSW` component to provide MSW context to child components.

### Package Updates:

* [`packages/browser-utils/package.json`](diffhunk://#diff-b5eec4c2cafe589b7eaf36ef41ed4c7037b85636335c4f9fb9d4624d17e03b8dL9-R9): Added MSW-related scripts, dependencies, and configurations. [[1]](diffhunk://#diff-b5eec4c2cafe589b7eaf36ef41ed4c7037b85636335c4f9fb9d4624d17e03b8dL9-R9) [[2]](diffhunk://#diff-b5eec4c2cafe589b7eaf36ef41ed4c7037b85636335c4f9fb9d4624d17e03b8dR23-R27) [[3]](diffhunk://#diff-b5eec4c2cafe589b7eaf36ef41ed4c7037b85636335c4f9fb9d4624d17e03b8dR43-R52)
* [`packages/browser-utils/src/msw/index.ts`](diffhunk://#diff-0a7145ea1dc780aaed91f2339274c2f8d66a4359922f0c811e0363ab74b7f214R1): Exported `initMockWorker` function.
* [`packages/browser-utils/src/msw/initMockWorker/index.ts`](diffhunk://#diff-711a3e11418a616f9f4b088bef0cd515aee76648a6ffdac902965fc86cb99d85R1-R25): Implemented `initMockWorker` function to initialize the mock worker.
* [`packages/browser-utils/vite.config.ts`](diffhunk://#diff-f0adfff0d9b0d460414698fa9afc4e51bea20e48462d457e0971bdfac4fa41eaR15): Added MSW entry point to Vite configuration.

### React Utils Updates:

* [`packages/react-utils/package.json`](diffhunk://#diff-ed47017c8d57a856394788fe12c953dcb28e67f5c9e4b7dd88c58de605bed48cR23-R27): Added MSW-related dependencies and configurations. [[1]](diffhunk://#diff-ed47017c8d57a856394788fe12c953dcb28e67f5c9e4b7dd88c58de605bed48cR23-R27) [[2]](diffhunk://#diff-ed47017c8d57a856394788fe12c953dcb28e67f5c9e4b7dd88c58de605bed48cR37-R39) [[3]](diffhunk://#diff-ed47017c8d57a856394788fe12c953dcb28e67f5c9e4b7dd88c58de605bed48cR49)
* [`packages/react-utils/src/providers/MSWProvider/index.tsx`](diffhunk://#diff-cce9a5cba8116e7f2440a9f6e9a1b18ed5cf3f649846ce632fe8e2df5bcfec73R1-R50): Created `MSWProvider` component to initialize and provide MSW context.
* [`packages/react-utils/src/providers/index.ts`](diffhunk://#diff-5c4d99a2703d1fc09563a23e22922317e6debe710b4cd4cc5dd1a96b7edb257dR1): Exported `MSWProvider`.
* [`packages/react-utils/vite.config.ts`](diffhunk://#diff-91bb717c937d0a819c104c865fbf9874dd4e89b95b6577a9baa68bf98a2f5b62R6-R17): Added `preserveDirective` plugin and MSW entry point to Vite configuration.

### Configuration Files:

* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR205-R208): Updated to include MSW and related dependencies. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR205-R208) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR382-R385) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR417-R419) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3797-R3801) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8279-R8283)
* [`turbo.json`](diffhunk://#diff-f8de965273949793edc0fbfe249bb458c0becde39b2e141db087bcbf5d4ad5e3L21-R22): Added `NODE_ENV` to global environment variables.