### PR TITLE
dev 태스크 실행 시 HMR 실패 문제 및 lint, check-types 태스크에서 dist 가 동기화되지 않아서 검증이 실패하던 문제 해결

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "@repo/react-ui": "workspace:*"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3",
     "@eslint/js": "^9.21.0",
-    "@repo/react-ui": "workspace:*",
     "@repo/eslint-config": "workspace:*",
     "@storybook/addon-essentials": "^8.6.11",
     "@storybook/blocks": "^8.6.11",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,16 +14,16 @@
     "@repo/ui": "workspace:*",
     "next": "^15.2.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
-  },
-  "devDependencies": {
-    "@repo/eslint-config": "workspace:*",
-    "@repo/typescript-config": "workspace:*",
+    "react-dom": "^19.0.0",
     "@repo/node-utils": "workspace:*",
     "@repo/browser-utils": "workspace:*",
     "@repo/react-utils": "workspace:*",
     "@repo/react-ui": "workspace:*",
-    "@repo/http-clients": "workspace:*",
+    "@repo/http-clients": "workspace:*"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
     "@types/node": "^22.13.10",
     "@types/react": "19.0.10",
     "@types/react-dom": "19.0.4",

--- a/packages/browser-utils/vite.config.ts
+++ b/packages/browser-utils/vite.config.ts
@@ -7,6 +7,7 @@ import tsConfigPaths from "vite-tsconfig-paths";
 export default defineConfig({
   plugins: [dtsPlugin(), tsConfigPaths()],
   build: {
+    emptyOutDir: false,
     lib: {
       name: "browser-utils",
       entry: {

--- a/packages/http-clients/vite.config.ts
+++ b/packages/http-clients/vite.config.ts
@@ -7,6 +7,7 @@ import tsConfigPaths from "vite-tsconfig-paths";
 export default defineConfig({
   plugins: [dtsPlugin(), tsConfigPaths()],
   build: {
+    emptyOutDir: false,
     lib: {
       name: "http-clients",
       entry: {

--- a/packages/node-utils/vite.config.ts
+++ b/packages/node-utils/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   plugins: [dtsPlugin(), tsConfigPaths()],
   build: {
     ssr: true,
+    emptyOutDir: false,
     rollupOptions: {
       input: {
         fs: resolve(__dirname, "src/fs/index.ts"),

--- a/packages/react-utils/vite.config.ts
+++ b/packages/react-utils/vite.config.ts
@@ -9,6 +9,7 @@ import { preserveDirective } from "rollup-preserve-directives";
 export default defineConfig({
   plugins: [dtsPlugin(), react(), tsConfigPaths(), preserveDirective()],
   build: {
+    emptyOutDir: false,
     lib: {
       name: "react-utils",
       entry: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
 
   apps/storybook:
     dependencies:
+      '@repo/react-ui':
+        specifier: workspace:*
+        version: link:../../packages/react-ui
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -82,9 +85,6 @@ importers:
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
-      '@repo/react-ui':
-        specifier: workspace:*
-        version: link:../../packages/react-ui
       '@storybook/addon-essentials':
         specifier: ^8.6.11
         version: 8.6.11(@types/react@19.0.10)(storybook@8.6.11(prettier@3.5.3))
@@ -154,6 +154,21 @@ importers:
 
   apps/web:
     dependencies:
+      '@repo/browser-utils':
+        specifier: workspace:*
+        version: link:../../packages/browser-utils
+      '@repo/http-clients':
+        specifier: workspace:*
+        version: link:../../packages/http-clients
+      '@repo/node-utils':
+        specifier: workspace:*
+        version: link:../../packages/node-utils
+      '@repo/react-ui':
+        specifier: workspace:*
+        version: link:../../packages/react-ui
+      '@repo/react-utils':
+        specifier: workspace:*
+        version: link:../../packages/react-utils
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -167,24 +182,9 @@ importers:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
     devDependencies:
-      '@repo/browser-utils':
-        specifier: workspace:*
-        version: link:../../packages/browser-utils
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
-      '@repo/http-clients':
-        specifier: workspace:*
-        version: link:../../packages/http-clients
-      '@repo/node-utils':
-        specifier: workspace:*
-        version: link:../../packages/node-utils
-      '@repo/react-ui':
-        specifier: workspace:*
-        version: link:../../packages/react-ui
-      '@repo/react-utils':
-        specifier: workspace:*
-        version: link:../../packages/react-utils
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config

--- a/turbo.json
+++ b/turbo.json
@@ -7,6 +7,9 @@
       "inputs": ["$TURBO_DEFAULT$", ".env*", "!**/*.stories.{tsx,jsx,mdx}"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**", "storybook-static/**"]
     },
+    "@repo/react-utils#build": {
+      "dependsOn": ["@repo/browser-utils#build"]
+    },
     "build:storybook": {},
     "lint": {
       "dependsOn": ["build", "^lint"]

--- a/turbo.json
+++ b/turbo.json
@@ -9,10 +9,10 @@
     },
     "build:storybook": {},
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": ["build", "^lint"]
     },
     "check-types": {
-      "dependsOn": ["^check-types"]
+      "dependsOn": ["build", "^check-types"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
This pull request includes various changes to dependencies and build configurations across multiple packages and applications. The most important changes include updates to `package.json` files, modifications to `vite.config.ts` files, and updates to the `pnpm-lock.yaml` and `turbo.json` files.

### Dependency Updates:
* [`apps/storybook/package.json`](diffhunk://#diff-b6c0dcaee715dbce8821255c58de066b960ad35ecd820d5bd09f912543b4ee4cL16-L21): Added `@repo/react-ui` to dependencies and removed it from devDependencies.
* [`apps/web/package.json`](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L17-R26): Reorganized dependencies and devDependencies, ensuring `@repo/react-ui` is correctly placed.

### Build Configuration Updates:
* [`packages/browser-utils/vite.config.ts`](diffhunk://#diff-f0adfff0d9b0d460414698fa9afc4e51bea20e48462d457e0971bdfac4fa41eaR10): Set `emptyOutDir` to false in the build configuration.
* [`packages/http-clients/vite.config.ts`](diffhunk://#diff-229fabc9a40fbc4f74f758c6675e6d05ecb7b94a0dbb6a162c66d9c80de66f1cR10): Set `emptyOutDir` to false in the build configuration.
* [`packages/node-utils/vite.config.ts`](diffhunk://#diff-69970cefb9f68882807914090b10a6f2eaee24c27e869f9c604572b1815a5e5aR11): Set `emptyOutDir` to false in the build configuration.
* [`packages/react-utils/vite.config.ts`](diffhunk://#diff-91bb717c937d0a819c104c865fbf9874dd4e89b95b6577a9baa68bf98a2f5b62R12): Set `emptyOutDir` to false in the build configuration.

### Lockfile Updates:
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR69-R71): Updated dependencies and devDependencies for `apps/storybook` and `apps/web` to reflect the changes in `package.json` files. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR69-R71) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL85-L87) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR157-R171) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL170-L187)

### Turbo Configuration Update:
* [`turbo.json`](diffhunk://#diff-f8de965273949793edc0fbfe249bb458c0becde39b2e141db087bcbf5d4ad5e3R10-R18): Added a build dependency for `@repo/react-utils` on `@repo/browser-utils` and updated dependencies for linting and type-checking tasks.