### PR TITLE
`browser-utils` 패키지에 `vitest` 사용 환경 구성

### DIFF
--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -37,6 +37,7 @@
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@types/node": "^22.13.10",
+    "@vitest/coverage-v8": "^3.1.1",
     "eslint": "^9.23.0",
     "typescript": "5.8.2",
     "vite": "^6.2.5",

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -8,6 +8,9 @@
     "check-types": "tsc --noEmit",
     "dev": "pnpm dlx msw init && tsc && vite build --watch",
     "build": "tsc && vite build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage",
     "preview": "vite preview"
   },
   "exports": {

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -39,6 +39,7 @@
     "@types/node": "^22.13.10",
     "@vitest/coverage-v8": "^3.1.1",
     "eslint": "^9.23.0",
+    "jsdom": "^26.0.0",
     "typescript": "5.8.2",
     "vite": "^6.2.5",
     "vite-plugin-dts": "^4.5.3",

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -38,7 +38,8 @@
     "typescript": "5.8.2",
     "vite": "^6.2.5",
     "vite-plugin-dts": "^4.5.3",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.1.1"
   },
   "dependencies": {
     "msw": "2.4.3"

--- a/packages/browser-utils/src/dom/alertHelloWorld/index.spec.ts
+++ b/packages/browser-utils/src/dom/alertHelloWorld/index.spec.ts
@@ -1,13 +1,11 @@
 import { describe, test, expect, vi } from "vitest";
 
 describe("alertHelloWorld()", () => {
-  test("should alert 'Hello World'", () => {
+  test("should alert 'Hello World'", async () => {
     const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
-    import(".").then((module) => {
-      const alertHelloWorld = module.default;
-      alertHelloWorld();
-      expect(alertMock).toHaveBeenCalledWith("Hello World");
-      alertMock.mockRestore();
-    });
+    const { default: alertHelloWorld } = await import(".");
+    alertHelloWorld();
+    expect(alertMock).toHaveBeenCalledWith("Hello World");
+    alertMock.mockRestore();
   });
 });

--- a/packages/browser-utils/src/dom/alertHelloWorld/index.spec.ts
+++ b/packages/browser-utils/src/dom/alertHelloWorld/index.spec.ts
@@ -1,0 +1,13 @@
+import { describe, test, expect, vi } from "vitest";
+
+describe("alertHelloWorld()", () => {
+  test("should alert 'Hello World'", () => {
+    const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
+    import(".").then((module) => {
+      const alertHelloWorld = module.default;
+      alertHelloWorld();
+      expect(alertMock).toHaveBeenCalledWith("Hello World");
+      alertMock.mockRestore();
+    });
+  });
+});

--- a/packages/browser-utils/src/string/isEmptyString/index.spec.ts
+++ b/packages/browser-utils/src/string/isEmptyString/index.spec.ts
@@ -1,0 +1,14 @@
+import isEmptyString from ".";
+import { describe, test, expect } from "vitest";
+
+describe("isEmptyString()", () => {
+  test("should return true when an empty string is provided", () => {
+    expect(isEmptyString("")).toBe(true);
+  });
+  test("should return true when a string with only spaces is provided", () => {
+    expect(isEmptyString("   ")).toBe(true);
+  });
+  test("should return false when a non-empty string is provided", () => {
+    expect(isEmptyString("Hello")).toBe(false);
+  });
+});

--- a/packages/browser-utils/vite.config.ts
+++ b/packages/browser-utils/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
   },
   resolve: { alias: { src: resolve(__dirname, "src/") } },
   test: {
+    environment: "jsdom",
     coverage: {
       provider: "v8",
       reporter: ["json"],

--- a/packages/browser-utils/vite.config.ts
+++ b/packages/browser-utils/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from "vite";
 import { resolve } from "path";
 import dtsPlugin from "vite-plugin-dts";
@@ -20,4 +21,10 @@ export default defineConfig({
     },
   },
   resolve: { alias: { src: resolve(__dirname, "src/") } },
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["json"],
+    },
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
         version: 8.6.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.11(prettier@3.5.3))
       '@storybook/experimental-addon-test':
         specifier: ^8.6.11
-        version: 8.6.11(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(@vitest/runner@3.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.11(prettier@3.5.3))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3)))
+        version: 8.6.11(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(@vitest/runner@3.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.11(prettier@3.5.3))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3)))
       '@storybook/react':
         specifier: ^8.6.11
         version: 8.6.11(@storybook/test@8.6.11(storybook@8.6.11(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.11(prettier@3.5.3))(typescript@5.7.3)
@@ -117,7 +117,7 @@ importers:
         version: 3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1)
       '@vitest/coverage-v8':
         specifier: ^3.1.1
-        version: 3.1.1(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3)))
+        version: 3.1.1(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3)))
       eslint:
         specifier: ^9.21.0
         version: 9.23.0(jiti@2.4.2)
@@ -150,7 +150,7 @@ importers:
         version: 6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))
+        version: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))
 
   apps/web:
     dependencies:
@@ -221,10 +221,13 @@ importers:
         version: 22.13.10
       '@vitest/coverage-v8':
         specifier: ^3.1.1
-        version: 3.1.1(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.8.2))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2)))
+        version: 3.1.1(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.8.2))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2)))
       eslint:
         specifier: ^9.23.0
         version: 9.23.0(jiti@2.4.2)
+      jsdom:
+        specifier: ^26.0.0
+        version: 26.0.0
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -239,7 +242,7 @@ importers:
         version: 5.1.4(typescript@5.8.2)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2))
+        version: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2))
 
   packages/eslint-config:
     devDependencies:
@@ -549,6 +552,9 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@asamuzakjp/css-color@3.1.1':
+    resolution: {integrity: sha512-hpRD68SV2OMcZCsrbdkccTw5FXjNDLo5OuqSHyHZfwweGsDWZwDJ2+gONyNAbazZclobMirACLw0lk8WVxIqxA==}
+
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
@@ -727,6 +733,34 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@5.0.2':
+    resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.2':
+    resolution: {integrity: sha512-TklMyb3uBB28b5uQdxjReG4L80NxAqgrECqLZFQbyLekwwlcDDS8r3f07DKqeo8C4926Br0gf/ZDe17Zv4wIuw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.4
+      '@csstools/css-tokenizer': ^3.0.3
+
+  '@csstools/css-color-parser@3.0.8':
+    resolution: {integrity: sha512-pdwotQjCCnRPuNi06jFuP68cykU1f3ZWExLe/8MQ1LOs8Xq+fTkYgd+2V8mWUWMrOn9iS2HftPVaMZDaXzGbhQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.4
+      '@csstools/css-tokenizer': ^3.0.3
+
+  '@csstools/css-parser-algorithms@3.0.4':
+    resolution: {integrity: sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.3
+
+  '@csstools/css-tokenizer@3.0.3':
+    resolution: {integrity: sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==}
+    engines: {node: '>=18'}
 
   '@emnapi/runtime@1.4.0':
     resolution: {integrity: sha512-64WYIf4UYcdLnbKn/umDlNjQDSS8AgZrI/R9+x5ilkUVFxXcA1Ebl+gQLc/6mERA4407Xof0R7wEyEuj091CVw==}
@@ -2337,6 +2371,10 @@ packages:
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
+  cssstyle@4.3.0:
+    resolution: {integrity: sha512-6r0NiY0xizYqfBvWp1G7WXJ06/bZyrk7Dc6PHql82C/pKGUTKu4yAX4Y8JPamb1ob9nBKuxWzCGTRuGwU3yxJQ==}
+    engines: {node: '>=18'}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
@@ -2347,6 +2385,10 @@ packages:
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -2375,6 +2417,9 @@ packages:
   decamelize@4.0.0:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
+
+  decimal.js@10.5.0:
+    resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -2961,6 +3006,10 @@ packages:
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -2983,6 +3032,10 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -3150,6 +3203,9 @@ packages:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -3265,6 +3321,15 @@ packages:
   jsdoc-type-pratt-parser@4.1.0:
     resolution: {integrity: sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==}
     engines: {node: '>=12.0.0'}
+
+  jsdom@26.0.0:
+    resolution: {integrity: sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -3670,6 +3735,9 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  nwsapi@2.2.20:
+    resolution: {integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3773,6 +3841,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse5@7.2.1:
+    resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
 
   pascal-case@2.0.1:
     resolution: {integrity: sha512-qjS4s8rBOJa2Xm0jmxXiyh1+OFf6ekCWOvUaRgAQSktzlTbMotS0nmG9gyYAybCWBcuP4fsBeRCKNwGBnMe2OQ==}
@@ -4059,6 +4130,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -4090,6 +4164,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
@@ -4343,6 +4421,9 @@ packages:
   swap-case@1.1.2:
     resolution: {integrity: sha512-BAmWG6/bx8syfc6qXPprof3Mn5vQgf5dwdUNJhsNqU9WdPt5P+ES/wQ5bxfijy8zwZgZZHslC3iAsxsuQMCzJQ==}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@3.0.2:
     resolution: {integrity: sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==}
 
@@ -4398,6 +4479,13 @@ packages:
   title-case@2.1.1:
     resolution: {integrity: sha512-EkJoZ2O3zdCz3zJsYCsxyq2OC5hrxR9mfdd5I+w8h/tmFfeOxJ+vvkxsKxdmN0WtS9zLdHEgfgVOiMVgv+Po4Q==}
 
+  tldts-core@6.1.85:
+    resolution: {integrity: sha512-DTjUVvxckL1fIoPSb3KE7ISNtkWSawZdpfxGxwiIrZoO6EbHVDXXUIlIuWympPaeS+BLGyggozX/HTMsRAdsoA==}
+
+  tldts@6.1.85:
+    resolution: {integrity: sha512-gBdZ1RjCSevRPFix/hpaUWeak2/RNUZB4/8frF1r5uYMHjFptkiT0JXIebWvgI/0ZHXvxaUDDJshiA0j6GdL3w==}
+    hasBin: true
+
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
@@ -4413,6 +4501,14 @@ packages:
   tough-cookie@4.1.4:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.0:
+    resolution: {integrity: sha512-IUWnUK7ADYR5Sl1fZlO1INDUhVhatWl7BtJWsIhwJ0UAK7ilzzIa8uIqOO/aYVWHZPJkKbEL+362wrzoeRF7bw==}
+    engines: {node: '>=18'}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -4707,11 +4803,31 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -4780,6 +4896,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -4826,6 +4949,14 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
+
+  '@asamuzakjp/css-color@3.1.1':
+    dependencies:
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -5087,6 +5218,26 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@5.0.2': {}
+
+  '@csstools/css-calc@2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+
+  '@csstools/css-color-parser@3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
+    dependencies:
+      '@csstools/color-helpers': 5.0.2
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+
+  '@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.3
+
+  '@csstools/css-tokenizer@3.0.3': {}
 
   '@emnapi/runtime@1.4.0':
     dependencies:
@@ -5730,7 +5881,7 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
-  '@storybook/experimental-addon-test@8.6.11(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(@vitest/runner@3.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.11(prettier@3.5.3))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3)))':
+  '@storybook/experimental-addon-test@8.6.11(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(@vitest/runner@3.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.11(prettier@3.5.3))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3)))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -5743,7 +5894,7 @@ snapshots:
     optionalDependencies:
       '@vitest/browser': 3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1)
       '@vitest/runner': 3.1.1
-      vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))
+      vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))
     transitivePeerDependencies:
       - react
       - react-dom
@@ -6227,7 +6378,7 @@ snapshots:
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))
+      vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))
       ws: 8.18.1
     optionalDependencies:
       playwright: 1.51.1
@@ -6246,7 +6397,7 @@ snapshots:
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2))
+      vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2))
       ws: 8.18.1
     optionalDependencies:
       playwright: 1.51.1
@@ -6257,7 +6408,7 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/coverage-v8@3.1.1(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3)))':
+  '@vitest/coverage-v8@3.1.1(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3)))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -6271,13 +6422,13 @@ snapshots:
       std-env: 3.8.1
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))
+      vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))
     optionalDependencies:
       '@vitest/browser': 3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.1.1(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.8.2))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2)))':
+  '@vitest/coverage-v8@3.1.1(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.8.2))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2)))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -6291,7 +6442,7 @@ snapshots:
       std-env: 3.8.1
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2))
+      vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2))
     optionalDependencies:
       '@vitest/browser': 3.1.1(msw@2.4.3(typescript@5.8.2))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1)
     transitivePeerDependencies:
@@ -6885,11 +7036,21 @@ snapshots:
 
   css.escape@1.5.1: {}
 
+  cssstyle@4.3.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.1.1
+      rrweb-cssom: 0.8.0
+
   csstype@3.1.3: {}
 
   dargs@8.1.0: {}
 
   data-uri-to-buffer@6.0.2: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -6918,6 +7079,8 @@ snapshots:
       supports-color: 8.1.1
 
   decamelize@4.0.0: {}
+
+  decimal.js@10.5.0: {}
 
   deep-eql@5.0.2: {}
 
@@ -7660,6 +7823,10 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-escaper@2.0.2: {}
 
   http-proxy-agent@7.0.2:
@@ -7681,6 +7848,10 @@ snapshots:
   husky@9.1.7: {}
 
   iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -7857,6 +8028,8 @@ snapshots:
 
   is-plain-obj@2.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -7976,6 +8149,34 @@ snapshots:
   jsbn@1.1.0: {}
 
   jsdoc-type-pratt-parser@4.1.0: {}
+
+  jsdom@26.0.0:
+    dependencies:
+      cssstyle: 4.3.0
+      data-urls: 5.0.0
+      decimal.js: 10.5.0
+      form-data: 4.0.2
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.20
+      parse5: 7.2.1
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -8383,6 +8584,8 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
+  nwsapi@2.2.20: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -8528,6 +8731,10 @@ snapshots:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse5@7.2.1:
+    dependencies:
+      entities: 4.5.0
 
   pascal-case@2.0.1:
     dependencies:
@@ -8844,6 +9051,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.39.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   run-async@2.4.1: {}
 
   run-parallel@1.2.0:
@@ -8880,6 +9089,10 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.25.0: {}
 
@@ -9167,6 +9380,8 @@ snapshots:
       lower-case: 1.1.4
       upper-case: 1.1.3
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@3.0.2: {}
 
   tailwindcss@4.0.17: {}
@@ -9209,6 +9424,12 @@ snapshots:
       no-case: 2.3.2
       upper-case: 1.1.3
 
+  tldts-core@6.1.85: {}
+
+  tldts@6.1.85:
+    dependencies:
+      tldts-core: 6.1.85
+
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
@@ -9225,6 +9446,14 @@ snapshots:
       punycode: 2.3.1
       universalify: 0.2.0
       url-parse: 1.5.10
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.85
+
+  tr46@5.1.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.1.0(typescript@5.7.3):
     dependencies:
@@ -9495,7 +9724,7 @@ snapshots:
       jiti: 2.4.2
       lightningcss: 1.29.2
 
-  vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3)):
+  vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3)):
     dependencies:
       '@vitest/expect': 3.1.1
       '@vitest/mocker': 3.1.1(msw@2.4.3(typescript@5.7.3))(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))
@@ -9520,6 +9749,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.10
       '@vitest/browser': 3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1)
+      jsdom: 26.0.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -9534,7 +9764,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2)):
+  vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2)):
     dependencies:
       '@vitest/expect': 3.1.1
       '@vitest/mocker': 3.1.1(msw@2.4.3(typescript@5.8.2))(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))
@@ -9559,6 +9789,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.10
       '@vitest/browser': 3.1.1(msw@2.4.3(typescript@5.8.2))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1)
+      jsdom: 26.0.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -9575,11 +9806,28 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
 
+  webidl-conversions@7.0.0: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.0
+      webidl-conversions: 7.0.0
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -9661,6 +9909,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.1: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.8.2)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))
+      vitest:
+        specifier: ^3.1.1
+        version: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2))
 
   packages/eslint-config:
     devDependencies:
@@ -6231,6 +6234,26 @@ snapshots:
       - utf-8-validate
       - vite
 
+  '@vitest/browser@3.1.1(msw@2.4.3(typescript@5.8.2))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@vitest/mocker': 3.1.1(msw@2.4.3(typescript@5.8.2))(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))
+      '@vitest/utils': 3.1.1
+      magic-string: 0.30.17
+      sirv: 3.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2))
+      ws: 8.18.1
+    optionalDependencies:
+      playwright: 1.51.1
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/coverage-v8@3.1.1(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3)))':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -6272,6 +6295,15 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.4.3(typescript@5.7.3)
+      vite: 6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)
+
+  '@vitest/mocker@3.1.1(msw@2.4.3(typescript@5.8.2))(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))':
+    dependencies:
+      '@vitest/spy': 3.1.1
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      msw: 2.4.3(typescript@5.8.2)
       vite: 6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)
 
   '@vitest/pretty-format@2.0.5':
@@ -9465,6 +9497,45 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.10
       '@vitest/browser': 3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2)):
+    dependencies:
+      '@vitest/expect': 3.1.1
+      '@vitest/mocker': 3.1.1(msw@2.4.3(typescript@5.8.2))(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))
+      '@vitest/pretty-format': 3.1.1
+      '@vitest/runner': 3.1.1
+      '@vitest/snapshot': 3.1.1
+      '@vitest/spy': 3.1.1
+      '@vitest/utils': 3.1.1
+      chai: 5.2.0
+      debug: 4.4.0(supports-color@8.1.1)
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.8.1
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)
+      vite-node: 3.1.1(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.13.10
+      '@vitest/browser': 3.1.1(msw@2.4.3(typescript@5.8.2))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1)
     transitivePeerDependencies:
       - jiti
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@types/node':
         specifier: ^22.13.10
         version: 22.13.10
+      '@vitest/coverage-v8':
+        specifier: ^3.1.1
+        version: 3.1.1(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.8.2))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2)))
       eslint:
         specifier: ^9.23.0
         version: 9.23.0(jiti@2.4.2)
@@ -6271,6 +6274,26 @@ snapshots:
       vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))
     optionalDependencies:
       '@vitest/browser': 3.1.1(msw@2.4.3(typescript@5.7.3))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-v8@3.1.1(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.8.2))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2)))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      debug: 4.4.0(supports-color@8.1.1)
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.1.7
+      magic-string: 0.30.17
+      magicast: 0.3.5
+      std-env: 3.8.1
+      test-exclude: 7.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2))
+    optionalDependencies:
+      '@vitest/browser': 3.1.1(msw@2.4.3(typescript@5.8.2))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
This pull request introduces testing capabilities to the `packages/browser-utils` package by integrating the Vitest testing framework. The changes include adding new scripts for running tests, updating dependencies, configuring Vitest in the Vite configuration, and adding test cases for existing functions.

### Testing Integration:

* [`packages/browser-utils/package.json`](diffhunk://#diff-b5eec4c2cafe589b7eaf36ef41ed4c7037b85636335c4f9fb9d4624d17e03b8dR11-R13): Added scripts for testing (`test`, `test:watch`, `coverage`) and included new dependencies (`@vitest/coverage-v8`, `jsdom`, `vitest`). [[1]](diffhunk://#diff-b5eec4c2cafe589b7eaf36ef41ed4c7037b85636335c4f9fb9d4624d17e03b8dR11-R13) [[2]](diffhunk://#diff-b5eec4c2cafe589b7eaf36ef41ed4c7037b85636335c4f9fb9d4624d17e03b8dR40-R47)

* [`packages/browser-utils/vite.config.ts`](diffhunk://#diff-f0adfff0d9b0d460414698fa9afc4e51bea20e48462d457e0971bdfac4fa41eaR1): Configured Vitest with a `jsdom` environment and coverage reporting using `v8`. [[1]](diffhunk://#diff-f0adfff0d9b0d460414698fa9afc4e51bea20e48462d457e0971bdfac4fa41eaR1) [[2]](diffhunk://#diff-f0adfff0d9b0d460414698fa9afc4e51bea20e48462d457e0971bdfac4fa41eaR24-R30)

### Test Cases:

* [`packages/browser-utils/src/dom/alertHelloWorld/index.spec.ts`](diffhunk://#diff-871450a4745240ab6aa4a2ba34f2e843f0f61fc8a61ca6f86fcf2fa6caba6c96R1-R13): Added test cases for the `alertHelloWorld` function using Vitest.

* [`packages/browser-utils/src/string/isEmptyString/index.spec.ts`](diffhunk://#diff-44006fabeab657f7bbfd090a6066bc29cba09716fc013caefd004f2f3926c315R1-R14): Added test cases for the `isEmptyString` function using Vitest.

### Dependency Updates:

* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL96-R96): Updated to include new dependencies and their respective versions required for Vitest and other new packages. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL96-R96) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL120-R120) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL153-R153) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR222-R230) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR243-R245) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR555-R557) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR737-R764) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2374-R2377) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2389-R2392) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2421-R2423) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3009-R3012) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3037-R3040) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3206-R3208) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3325-R3333) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3738-R3740) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3845-R3847) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4133-R4135) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4168-R4171) [[19]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4424-R4426) [[20]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4482-R4488) [[21]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4505-R4512)