### PR TITLE
`node-utils` 패키지에 `vitest` 사용 환경 구성

### DIFF
--- a/packages/node-utils/package.json
+++ b/packages/node-utils/package.json
@@ -41,7 +41,8 @@
     "typescript": "5.8.2",
     "vite": "^6.2.0",
     "vite-plugin-dts": "^4.5.3",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.1.1"
   },
   "engines": {
     "node": ">=22"

--- a/packages/node-utils/package.json
+++ b/packages/node-utils/package.json
@@ -8,6 +8,9 @@
     "check-types": "tsc --noEmit",
     "dev": "tsc && vite build --watch",
     "build": "tsc && vite build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage",
     "preview": "vite preview"
   },
   "exports": {

--- a/packages/node-utils/package.json
+++ b/packages/node-utils/package.json
@@ -40,6 +40,7 @@
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@types/node": "^22.13.10",
+    "@vitest/coverage-v8": "^3.1.1",
     "eslint": "^9.23.0",
     "typescript": "5.8.2",
     "vite": "^6.2.0",

--- a/packages/node-utils/src/fs/ls/index.spec.ts
+++ b/packages/node-utils/src/fs/ls/index.spec.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect, vi } from "vitest";
+import fs, { Dirent, Stats } from "fs";
+import ls from ".";
+
+describe("ls()", () => {
+  test("should list files in the current directory", async () => {
+    // @ts-expect-error TS2322: Type 'string' is not assignable to type 'Dirent'.
+    const mockFiles: Dirent[] = ["file1.txt", "file2.txt"];
+    // @ts-expect-error TS2740
+    const mockStats: Stats = {
+      isDirectory: vi.fn(() => false),
+      size: 1_234,
+      // eslint-disable-next-line sample/no-new-date
+      mtime: new Date(),
+    };
+
+    vi.spyOn(fs, "readdirSync").mockReturnValue(mockFiles);
+    vi.spyOn(fs, "statSync").mockReturnValue(mockStats);
+
+    const result = ls();
+
+    expect(result).toEqual([
+      {
+        name: "file1.txt",
+        isDirectory: false,
+        size: 1234,
+        lastModified: mockStats.mtime,
+      },
+      {
+        name: "file2.txt",
+        isDirectory: false,
+        size: 1234,
+        lastModified: mockStats.mtime,
+      },
+    ]);
+
+    expect(fs.readdirSync).toHaveBeenCalledWith(process.cwd());
+    expect(fs.statSync).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/node-utils/src/misc/isInNodeRuntime/index.spec.ts
+++ b/packages/node-utils/src/misc/isInNodeRuntime/index.spec.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect, vi } from "vitest";
+import isInNodeRuntime from ".";
+
+describe("isInNodeRuntime()", () => {
+  test("should return true when running in Node.js environment", async () => {
+    // Call the function and check the result
+    expect(isInNodeRuntime()).toBe(true);
+  });
+  test("should return false when running in a browser environment", async () => {
+    // Mock the global objects to simulate a browser environment
+    const windowSpy = vi
+      .spyOn(globalThis, "global", "get")
+      // @ts-expect-error TS2322
+      .mockImplementation(() => undefined);
+
+    // Call the function and check the result
+    expect(isInNodeRuntime()).toBe(false);
+
+    // Restore the original global objects
+    windowSpy.mockRestore();
+  });
+});

--- a/packages/node-utils/vite.config.ts
+++ b/packages/node-utils/vite.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
     noExternal: true,
   },
   test: {
+    environment: "node",
     coverage: {
       provider: "v8",
       reporter: ["json"],

--- a/packages/node-utils/vite.config.ts
+++ b/packages/node-utils/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from "vite";
 import { resolve } from "path";
 import dtsPlugin from "vite-plugin-dts";
@@ -32,5 +33,11 @@ export default defineConfig({
   resolve: { alias: { src: resolve(__dirname, "src/") } },
   ssr: {
     noExternal: true,
+  },
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["json"],
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,9 @@ importers:
       '@types/node':
         specifier: ^22.13.10
         version: 22.13.10
+      '@vitest/coverage-v8':
+        specifier: ^3.1.1
+        version: 3.1.1(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.8.2))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2)))
       eslint:
         specifier: ^9.23.0
         version: 9.23.0(jiti@2.4.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,6 +375,9 @@ importers:
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.8.2)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))
+      vitest:
+        specifier: ^3.1.1
+        version: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2))
 
   packages/react-ui:
     dependencies:


### PR DESCRIPTION
This pull request introduces testing capabilities using Vitest and adds coverage reporting to the `node-utils` package. The most important changes include updates to the `package.json` file, new test files, and modifications to the Vite configuration.

### Testing and Coverage:

* [`packages/node-utils/package.json`](diffhunk://#diff-218d6f82fdd8813a3f0ca557b4711d8acea3d7e84153caf400481c30b6a4c3a8R11-R13): Added new scripts for running tests and generating coverage reports, and added `@vitest/coverage-v8` and `vitest` as dependencies. [[1]](diffhunk://#diff-218d6f82fdd8813a3f0ca557b4711d8acea3d7e84153caf400481c30b6a4c3a8R11-R13) [[2]](diffhunk://#diff-218d6f82fdd8813a3f0ca557b4711d8acea3d7e84153caf400481c30b6a4c3a8R43-R49)
* [`packages/node-utils/vite.config.ts`](diffhunk://#diff-69970cefb9f68882807914090b10a6f2eaee24c27e869f9c604572b1815a5e5aR1): Configured Vitest environment and coverage provider in the Vite configuration. [[1]](diffhunk://#diff-69970cefb9f68882807914090b10a6f2eaee24c27e869f9c604572b1815a5e5aR1) [[2]](diffhunk://#diff-69970cefb9f68882807914090b10a6f2eaee24c27e869f9c604572b1815a5e5aR37-R43)

### New Test Files:

* [`packages/node-utils/src/fs/ls/index.spec.ts`](diffhunk://#diff-902740002062fb720e790e13d3f84ef8e733265edb3c00eab2318158fe746dc6R1-R40): Added tests for the `ls` function to verify it lists files in the current directory.
* [`packages/node-utils/src/misc/isInNodeRuntime/index.spec.ts`](diffhunk://#diff-3426e039b73679c0a1fba2c3382906d5078e18ef58eb446681582a0613bfb246R1-R22): Added tests for the `isInNodeRuntime` function to check its behavior in Node.js and browser environments.

### Dependency Updates:

* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR363-R365): Updated lock file to include the new dependencies `@vitest/coverage-v8` and `vitest`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR363-R365) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR381-R383)