### PR TITLE
`web` 어플리케이션에 `vitest` 사용 환경 구성

### DIFF
--- a/apps/web/components/FancyShadcnButton/index.spec.tsx
+++ b/apps/web/components/FancyShadcnButton/index.spec.tsx
@@ -1,0 +1,13 @@
+import { describe, test, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import FancyShadcnButton from ".";
+
+describe("<FancyShadcnButton/>", () => {
+  test("render", async () => {
+    render(<FancyShadcnButton />);
+    const button = await screen.getByRole("button", {
+      name: "shadcn/ui",
+    });
+    expect(button).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/FancyShadcnButton/index.spec.tsx
+++ b/apps/web/components/FancyShadcnButton/index.spec.tsx
@@ -3,9 +3,9 @@ import { render, screen } from "@testing-library/react";
 import FancyShadcnButton from ".";
 
 describe("<FancyShadcnButton/>", () => {
-  test("render", async () => {
+  test("render", () => {
     render(<FancyShadcnButton />);
-    const button = await screen.getByRole("button", {
+    const button = screen.getByRole("button", {
       name: "shadcn/ui",
     });
     expect(button).toBeInTheDocument();

--- a/apps/web/components/HelloWorldButton/index.spec.tsx
+++ b/apps/web/components/HelloWorldButton/index.spec.tsx
@@ -3,9 +3,9 @@ import { render, screen } from "@testing-library/react";
 import HelloWorldButton from ".";
 
 describe("<HelloWorldButton/>", () => {
-  test("render", async () => {
+  test("render", () => {
     render(<HelloWorldButton />);
-    const button = await screen.getByRole("button", {
+    const button = screen.getByRole("button", {
       name: "Click me!",
     });
     expect(button).toBeInTheDocument();

--- a/apps/web/components/HelloWorldButton/index.spec.tsx
+++ b/apps/web/components/HelloWorldButton/index.spec.tsx
@@ -1,0 +1,13 @@
+import { describe, test, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import HelloWorldButton from ".";
+
+describe("<HelloWorldButton/>", () => {
+  test("render", async () => {
+    render(<HelloWorldButton />);
+    const button = await screen.getByRole("button", {
+      name: "Click me!",
+    });
+    expect(button).toBeInTheDocument();
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint --max-warnings 0",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@repo/browser-utils": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
+    "@repo/vitest-config": "workspace:*",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,24 +11,32 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
+    "@repo/browser-utils": "workspace:*",
+    "@repo/http-clients": "workspace:*",
+    "@repo/node-utils": "workspace:*",
+    "@repo/react-ui": "workspace:*",
+    "@repo/react-utils": "workspace:*",
     "@repo/ui": "workspace:*",
     "next": "^15.2.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@repo/node-utils": "workspace:*",
-    "@repo/browser-utils": "workspace:*",
-    "@repo/react-utils": "workspace:*",
-    "@repo/react-ui": "workspace:*",
-    "@repo/http-clients": "workspace:*"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.13.10",
     "@types/react": "19.0.10",
     "@types/react-dom": "19.0.4",
+    "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.23.0",
-    "typescript": "5.8.2"
+    "jsdom": "^26.0.0",
+    "typescript": "5.8.2",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.1.1"
   },
   "engines": {
     "node": ">=22"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "@types/react": "19.0.10",
     "@types/react-dom": "19.0.4",
     "@vitejs/plugin-react": "^4.3.4",
+    "@vitest/coverage-v8": "^3.1.1",
     "eslint": "^9.23.0",
     "jsdom": "^26.0.0",
     "typescript": "5.8.2",

--- a/apps/web/tests/setup.ts
+++ b/apps/web/tests/setup.ts
@@ -1,0 +1,8 @@
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+// runs a clean after each test case (e.g. clearing jsdom)
+afterEach(() => {
+  cleanup();
+});

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -1,0 +1,12 @@
+import { mergeConfig, defineProject } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import tsconfigPaths from "vite-tsconfig-paths";
+import uiTestConfig from "@repo/vitest-config/ui";
+
+export default mergeConfig(
+  uiTestConfig,
+  defineProject({
+    plugins: [tsconfigPaths(), react()],
+    test: { setupFiles: ["./tests/setup.ts"] },
+  }),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
+      '@repo/vitest-config':
+        specifier: workspace:*
+        version: link:../../packages/vitest-config
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: link:../../packages/ui
       next:
         specifier: ^15.2.4
-        version: 15.2.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.2.4(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -174,7 +174,7 @@ importers:
         version: link:../../packages/ui
       next:
         specifier: ^15.2.4
-        version: 15.2.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.2.4(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -188,6 +188,18 @@ importers:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
+      '@testing-library/dom':
+        specifier: ^10.4.0
+        version: 10.4.0
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/node':
         specifier: ^22.13.10
         version: 22.13.10
@@ -197,12 +209,24 @@ importers:
       '@types/react-dom':
         specifier: 19.0.4
         version: 19.0.4(@types/react@19.0.10)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.3.4(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))
       eslint:
         specifier: ^9.23.0
         version: 9.23.0(jiti@2.4.2)
+      jsdom:
+        specifier: ^26.0.0
+        version: 26.0.0
       typescript:
         specifier: 5.8.2
         version: 5.8.2
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.8.2)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))
+      vitest:
+        specifier: ^3.1.1
+        version: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(@vitest/ui@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2))
 
   packages/browser-utils:
     dependencies:
@@ -6881,7 +6905,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.12
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(@vitest/ui@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))
+      vitest: 3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(@vitest/ui@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2))
 
   '@vitest/utils@2.0.5':
     dependencies:
@@ -9021,7 +9045,7 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next@15.2.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.2.4(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@next/env': 15.2.4
       '@swc/counter': 0.1.3
@@ -9031,7 +9055,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      styled-jsx: 5.1.6(react@19.0.0)
+      styled-jsx: 5.1.6(@babel/core@7.26.10)(react@19.0.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.2.4
       '@next/swc-darwin-x64': 15.2.4
@@ -9942,10 +9966,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.6(react@19.0.0):
+  styled-jsx@5.1.6(@babel/core@7.26.10)(react@19.0.0):
     dependencies:
       client-only: 0.0.1
       react: 19.0.0
+    optionalDependencies:
+      '@babel/core': 7.26.10
 
   supports-color@5.5.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))
+      '@vitest/coverage-v8':
+        specifier: ^3.1.1
+        version: 3.1.1(@vitest/browser@3.1.1(msw@2.4.3(typescript@5.8.2))(playwright@1.51.1)(vite@6.2.5(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2))(vitest@3.1.1))(vitest@3.1.1(@types/node@22.13.10)(@vitest/browser@3.1.1)(@vitest/ui@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2)))
       eslint:
         specifier: ^9.23.0
         version: 9.23.0(jiti@2.4.2)


### PR DESCRIPTION
This pull request introduces a testing setup for the `apps/web` project, including adding tests for existing components and updating dependencies to support testing. The most important changes include adding test files for components, updating the `package.json` to include testing scripts and dependencies, and configuring Vitest for the project.

### Testing Setup:

* [`apps/web/components/FancyShadcnButton/index.spec.tsx`](diffhunk://#diff-6bc7dc5441b413399f20e25343ff30dcdacb5b8e2162f1ef19df6c891f8e0e08R1-R13): Added a test file for the `FancyShadcnButton` component using Vitest and Testing Library.
* [`apps/web/components/HelloWorldButton/index.spec.tsx`](diffhunk://#diff-82cbee72ea4cb806f1176ab011ffb0c0a9060c0172432f62651b3eef08adca92R1-R13): Added a test file for the `HelloWorldButton` component using Vitest and Testing Library.
* [`apps/web/tests/setup.ts`](diffhunk://#diff-5e12c9bbfc3b58176d90ba3f436d4bf58a562951286356f2d1819afd59f31ffdR1-R8): Added a setup file to configure Vitest to clean up after each test case.
* [`apps/web/vitest.config.mts`](diffhunk://#diff-82544e703c2be573619a66b2de9b4e1f4eeae9f00fb7f6c09e0bdc788c51b912R1-R12): Created a Vitest configuration file to set up the testing environment with necessary plugins and setup files.

### Dependency and Script Updates:

* [`apps/web/package.json`](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L11-R44): Updated to include new scripts for running tests, added testing dependencies, and restructured existing dependencies.

### Lockfile Updates:

* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL37-R37): Updated to reflect the changes in dependencies and added new entries for testing libraries and configurations. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL37-R37) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL177-R177) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR191-R205) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR215-R235) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6884-R6914) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9024-R9054) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9034-R9064) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9945-R9980)