### PR TITLE
e2e-test 워크플로우에서 Docker 캐시 디렉토리 존재 여부 확인 단계 추가

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,6 +12,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Ensure Docker cache directory exists
+        run: mkdir -p /tmp/docker-cache
+
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
This pull request makes a small addition to the `.github/workflows/e2e-test.yml` file to ensure the Docker cache directory is created before setting up Docker Build.

* [`.github/workflows/e2e-test.yml`](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2R15-R17): Added a step to create the `/tmp/docker-cache` directory to prevent potential issues with missing directories during Docker operations.