### PR TITLE
`cli` 도구에 새로운 명령어 2종 추가

### DIFF
--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -10,6 +10,12 @@
   - `-l, --ls [value]`: 디렉토리 내용을 나열해요. `value`를 지정하지 않으면 현재 디렉토리를 나열해요.
   - `-m, --mkdir <value>`: 새로운 디렉토리를 생성해요.
   - `-t, --touch <value>`: 새로운 파일을 생성해요.
+- **[change-owner-name](./src/change-owner-name/index.ts)**: 코드베이스 내 모든 파일을 탐색하여 기존의 소유자 ID 가 기록되어 있는 부분을 replace 해주는 CLI 도구에요.
+  - `-n, --name <value>`: 새로운 소유자 이름을 지정해요.
+- **[rename-repository](./src/rename-repository/index.ts)**: 코드베이스 내 모든 파일을 탐색하여 레포지토리 이름이 기록되어 있는 부분을 replace 해주는 CLI 도구에요.
+  - `-n, --name <value>`: 새로운 레포지토리 이름을 지정해요.
+- **[rename-scope](./src/rename-scope/index.ts)**: 코드베이스 내 모든 파일을 탐색하여 기존의 패키지명 앞에 기록되어 있는 스코프 부분(e.g. `@repo/`)을 replace 해주는 CLI 도구에요.
+  - `-n, --name <value>`: 새로운 스코프 이름을 지정해요.
 
 ## ⬇️ 설치
 
@@ -47,6 +53,42 @@ example --mkdir <directory-name>
 
 ```bash
 example --touch <file-name>
+```
+
+### `change-owner-name` 명령어
+
+#### 소유자 ID 변경
+
+```bash
+change-owner-name -n your-username
+
+# or equivalently
+
+change-owner-name --name your-username
+```
+
+### `rename-repository` 명령어
+
+#### 레포지토리 이름 변경
+
+```bash
+rename-repository -n new-repository-name
+
+# or equivalently
+
+rename-repository --name new-repository-name
+```
+
+### `rename-scope` 명령어
+
+#### 스코프 이름 변경
+
+```bash
+rename-scope -n new-scope-name
+
+# or equivalently
+
+rename-scope --name new-scope-name
 ```
 
 ## 🤝 기여

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "bin": {
     "example": "./dist/example/index.js",
-    "rename-scope": "./dist/rename-scope/index.js"
+    "rename-scope": "./dist/rename-scope/index.js",
+    "rename-repository": "./dist/rename-repository/index.js"
   },
   "scripts": {
     "preinstall": "npx tsc -b",

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -5,7 +5,8 @@
   "bin": {
     "example": "./dist/example/index.js",
     "rename-scope": "./dist/rename-scope/index.js",
-    "rename-repository": "./dist/rename-repository/index.js"
+    "rename-repository": "./dist/rename-repository/index.js",
+    "change-owner-name": "./dist/change-owner-name/index.js"
   },
   "scripts": {
     "preinstall": "npx tsc -b",

--- a/tools/cli/src/change-owner-name/changeOwnerName/index.ts
+++ b/tools/cli/src/change-owner-name/changeOwnerName/index.ts
@@ -1,30 +1,5 @@
-import fs from "fs";
 import path from "path";
-import getStdoutUpdater from "../../utils/getStdoutUpdater";
-
-/**
- * Renames the scope of a package name in each file with the specified extension
- */
-const TARGET_EXTENSIONS = ["md", "json", "css", "ts", "tsx", "js", "jsx"];
-
-/**
- * Directories to exclude from renaming
- */
-const EXCLUDE_DIRS = [
-  "node_modules",
-  ".git",
-  ".devcontainer",
-  ".github",
-  ".husky",
-  ".idea",
-  ".turbo",
-  ".vscode",
-  ".next",
-  "dist",
-  "build",
-  "out",
-  "storybook-static",
-];
+import replaceAllInDirectory from "../../utils/replaceAllInDirectory";
 
 /**
  * Changes the owner name of the current repository
@@ -38,37 +13,6 @@ export default function changeOwnerName(targetName: string) {
   // current owner name
   const oldName = "iamhoonse-dev";
 
-  const updateStdout = getStdoutUpdater();
-
-  function replaceInFile(filePath: string) {
-    updateStdout("file : ", filePath);
-    const content = fs.readFileSync(filePath, "utf-8");
-    const updatedContent = content.replace(
-      new RegExp(oldName, "g"),
-      targetName,
-    );
-    fs.writeFileSync(filePath, updatedContent, "utf-8");
-  }
-
-  function processDirectory(directory: string) {
-    const entries = fs.readdirSync(directory, { withFileTypes: true });
-    for (const entry of entries) {
-      const fullPath = path.join(directory, entry.name);
-      const ext = path.extname(entry.name);
-      if (entry.isDirectory() && !EXCLUDE_DIRS.includes(entry.name)) {
-        processDirectory(fullPath);
-      } else if (
-        entry.isFile() &&
-        TARGET_EXTENSIONS.some((target) => ext.endsWith(target)) &&
-        fullPath !== __filename
-      ) {
-        replaceInFile(fullPath);
-      }
-    }
-  }
-
-  updateStdout("file : ", __filename);
-  updateStdout("rootDir : ", rootDir);
-  processDirectory(rootDir);
-  updateStdout.done();
+  // replace all occurrences of the old name with the new name
+  replaceAllInDirectory(rootDir, oldName, targetName);
 }

--- a/tools/cli/src/change-owner-name/changeOwnerName/index.ts
+++ b/tools/cli/src/change-owner-name/changeOwnerName/index.ts
@@ -1,0 +1,74 @@
+import fs from "fs";
+import path from "path";
+import getStdoutUpdater from "../../utils/getStdoutUpdater";
+
+/**
+ * Renames the scope of a package name in each file with the specified extension
+ */
+const TARGET_EXTENSIONS = ["md", "json", "css", "ts", "tsx", "js", "jsx"];
+
+/**
+ * Directories to exclude from renaming
+ */
+const EXCLUDE_DIRS = [
+  "node_modules",
+  ".git",
+  ".devcontainer",
+  ".github",
+  ".husky",
+  ".idea",
+  ".turbo",
+  ".vscode",
+  ".next",
+  "dist",
+  "build",
+  "out",
+  "storybook-static",
+];
+
+/**
+ * Changes the owner name of the current repository
+ *
+ * @param targetName - The new owner name
+ */
+export default function changeOwnerName(targetName: string) {
+  // get repository root directory
+  const rootDir = path.resolve(__dirname, "../../../../../"); // Adjust based on project structure
+
+  // current owner name
+  const oldName = "iamhoonse-dev";
+
+  const updateStdout = getStdoutUpdater();
+
+  function replaceInFile(filePath: string) {
+    updateStdout("file : ", filePath);
+    const content = fs.readFileSync(filePath, "utf-8");
+    const updatedContent = content.replace(
+      new RegExp(oldName, "g"),
+      targetName,
+    );
+    fs.writeFileSync(filePath, updatedContent, "utf-8");
+  }
+
+  function processDirectory(directory: string) {
+    const entries = fs.readdirSync(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(directory, entry.name);
+      const ext = path.extname(entry.name);
+      if (entry.isDirectory() && !EXCLUDE_DIRS.includes(entry.name)) {
+        processDirectory(fullPath);
+      } else if (
+        entry.isFile() &&
+        TARGET_EXTENSIONS.some((target) => ext.endsWith(target)) &&
+        fullPath !== __filename
+      ) {
+        replaceInFile(fullPath);
+      }
+    }
+  }
+
+  updateStdout("file : ", __filename);
+  updateStdout("rootDir : ", rootDir);
+  processDirectory(rootDir);
+  updateStdout.done();
+}

--- a/tools/cli/src/change-owner-name/index.ts
+++ b/tools/cli/src/change-owner-name/index.ts
@@ -18,7 +18,7 @@ program
   .description("A CLI for changing owner of repository")
   .option("-n, --name <value>", "New owner for repository")
   .action(async ({ name }) => {
-    await withSpinner(() => changeOwnerName(name), "Renaming repository...");
+    await withSpinner(() => changeOwnerName(name), "Changing owner...");
     await withSpinner(() => pnpmInstall(), "Updating dependencies...");
   })
   .parse(process.argv);

--- a/tools/cli/src/change-owner-name/index.ts
+++ b/tools/cli/src/change-owner-name/index.ts
@@ -1,0 +1,29 @@
+#! /usr/bin/env node
+
+import { textSync } from "figlet";
+import { Command } from "commander";
+import changeOwnerName from "./changeOwnerName";
+import withSpinner from "../utils/withSpinner";
+import pnpmInstall from "../utils/pnpm-install";
+
+// program is a command-line interface (CLI) library for Node.js
+const program = new Command();
+
+// ASCII art for the CLI
+console.log(textSync("Change Owner"));
+
+// This is a simple CLI program that allows you to rename repository
+program
+  .version("0.0.0")
+  .description("A CLI for changing owner of repository")
+  .option("-n, --name <value>", "New owner for repository")
+  .action(async ({ name }) => {
+    await withSpinner(() => changeOwnerName(name), "Renaming repository...");
+    await withSpinner(() => pnpmInstall(), "Updating dependencies...");
+  })
+  .parse(process.argv);
+
+// If no options are provided, display the help message
+if (!process.argv.slice(2).length) {
+  program.outputHelp();
+}

--- a/tools/cli/src/rename-repository/index.ts
+++ b/tools/cli/src/rename-repository/index.ts
@@ -1,0 +1,29 @@
+#! /usr/bin/env node
+
+import { textSync } from "figlet";
+import { Command } from "commander";
+import renameRepository from "./renameRepository";
+import withSpinner from "../utils/withSpinner";
+import pnpmInstall from "../utils/pnpm-install";
+
+// program is a command-line interface (CLI) library for Node.js
+const program = new Command();
+
+// ASCII art for the CLI
+console.log(textSync("Rename Repository"));
+
+// This is a simple CLI program that allows you to rename repository
+program
+  .version("0.0.0")
+  .description("A CLI for renaming repository")
+  .option("-n, --name <value>", "New name for repository")
+  .action(async ({ name }) => {
+    await withSpinner(() => renameRepository(name), "Renaming repository...");
+    await withSpinner(() => pnpmInstall(), "Updating dependencies...");
+  })
+  .parse(process.argv);
+
+// If no options are provided, display the help message
+if (!process.argv.slice(2).length) {
+  program.outputHelp();
+}

--- a/tools/cli/src/rename-repository/renameRepository/index.ts
+++ b/tools/cli/src/rename-repository/renameRepository/index.ts
@@ -1,30 +1,6 @@
 import fs from "fs";
 import path from "path";
-import getStdoutUpdater from "../../utils/getStdoutUpdater";
-
-/**
- * Renames the scope of a package name in each file with the specified extension
- */
-const TARGET_EXTENSIONS = ["md", "json", "css", "ts", "tsx", "js", "jsx"];
-
-/**
- * Directories to exclude from renaming
- */
-const EXCLUDE_DIRS = [
-  "node_modules",
-  ".git",
-  ".devcontainer",
-  ".github",
-  ".husky",
-  ".idea",
-  ".turbo",
-  ".vscode",
-  ".next",
-  "dist",
-  "build",
-  "out",
-  "storybook-static",
-];
+import replaceAllInDirectory from "../../utils/replaceAllInDirectory";
 
 /**
  * Renames current repository
@@ -42,37 +18,6 @@ export default function renameRepository(targetName: string) {
   );
   const oldName = rootPackageJson.name;
 
-  const updateStdout = getStdoutUpdater();
-
-  function replaceInFile(filePath: string) {
-    updateStdout("file : ", filePath);
-    const content = fs.readFileSync(filePath, "utf-8");
-    const updatedContent = content.replace(
-      new RegExp(oldName, "g"),
-      targetName,
-    );
-    fs.writeFileSync(filePath, updatedContent, "utf-8");
-  }
-
-  function processDirectory(directory: string) {
-    const entries = fs.readdirSync(directory, { withFileTypes: true });
-    for (const entry of entries) {
-      const fullPath = path.join(directory, entry.name);
-      const ext = path.extname(entry.name);
-      if (entry.isDirectory() && !EXCLUDE_DIRS.includes(entry.name)) {
-        processDirectory(fullPath);
-      } else if (
-        entry.isFile() &&
-        TARGET_EXTENSIONS.some((target) => ext.endsWith(target)) &&
-        fullPath !== __filename
-      ) {
-        replaceInFile(fullPath);
-      }
-    }
-  }
-
-  updateStdout("file : ", __filename);
-  updateStdout("rootDir : ", rootDir);
-  processDirectory(rootDir);
-  updateStdout.done();
+  // replace all occurrences of the old name with the new name
+  replaceAllInDirectory(rootDir, oldName, targetName);
 }

--- a/tools/cli/src/rename-repository/renameRepository/index.ts
+++ b/tools/cli/src/rename-repository/renameRepository/index.ts
@@ -1,0 +1,78 @@
+import fs from "fs";
+import path from "path";
+import getStdoutUpdater from "../../utils/getStdoutUpdater";
+
+/**
+ * Renames the scope of a package name in each file with the specified extension
+ */
+const TARGET_EXTENSIONS = ["md", "json", "css", "ts", "tsx", "js", "jsx"];
+
+/**
+ * Directories to exclude from renaming
+ */
+const EXCLUDE_DIRS = [
+  "node_modules",
+  ".git",
+  ".devcontainer",
+  ".github",
+  ".husky",
+  ".idea",
+  ".turbo",
+  ".vscode",
+  ".next",
+  "dist",
+  "build",
+  "out",
+  "storybook-static",
+];
+
+/**
+ * Renames current repository
+ *
+ * @param targetName - The new name for the repository
+ */
+export default function renameRepository(targetName: string) {
+  // get repository root directory
+  const rootDir = path.resolve(__dirname, "../../../../../"); // Adjust based on project structure
+
+  // get current repository name
+  const rootPackageJsonPath = path.join(rootDir, "package.json");
+  const rootPackageJson = JSON.parse(
+    fs.readFileSync(rootPackageJsonPath, "utf-8"),
+  );
+  const oldName = rootPackageJson.name;
+
+  const updateStdout = getStdoutUpdater();
+
+  function replaceInFile(filePath: string) {
+    updateStdout("file : ", filePath);
+    const content = fs.readFileSync(filePath, "utf-8");
+    const updatedContent = content.replace(
+      new RegExp(oldName, "g"),
+      targetName,
+    );
+    fs.writeFileSync(filePath, updatedContent, "utf-8");
+  }
+
+  function processDirectory(directory: string) {
+    const entries = fs.readdirSync(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(directory, entry.name);
+      const ext = path.extname(entry.name);
+      if (entry.isDirectory() && !EXCLUDE_DIRS.includes(entry.name)) {
+        processDirectory(fullPath);
+      } else if (
+        entry.isFile() &&
+        TARGET_EXTENSIONS.some((target) => ext.endsWith(target)) &&
+        fullPath !== __filename
+      ) {
+        replaceInFile(fullPath);
+      }
+    }
+  }
+
+  updateStdout("file : ", __filename);
+  updateStdout("rootDir : ", rootDir);
+  processDirectory(rootDir);
+  updateStdout.done();
+}

--- a/tools/cli/src/rename-scope/renameScope/index.ts
+++ b/tools/cli/src/rename-scope/renameScope/index.ts
@@ -1,30 +1,5 @@
-import fs from "fs";
 import path from "path";
-import getStdoutUpdater from "../../utils/getStdoutUpdater";
-
-/**
- * Renames the scope of a package name in each file with the specified extension
- */
-const TARGET_EXTENSIONS = ["md", "json", "css", "ts", "tsx", "js", "jsx"];
-
-/**
- * Directories to exclude from renaming
- */
-const EXCLUDE_DIRS = [
-  "node_modules",
-  ".git",
-  ".devcontainer",
-  ".github",
-  ".husky",
-  ".idea",
-  ".turbo",
-  ".vscode",
-  ".next",
-  "dist",
-  "build",
-  "out",
-  "storybook-static",
-];
+import replaceAllInDirectory from "../../utils/replaceAllInDirectory";
 
 /**
  * Renames the scope of a package name from @foo/ to @<name>/
@@ -32,41 +7,15 @@ const EXCLUDE_DIRS = [
  * @param name - The new name for the package scope
  */
 export default function renameScope(name: string) {
-  const targetScope = `@${name}/`;
-  const oldScope = "@repo/";
+  // get repository root directory
   const rootDir = path.resolve(__dirname, "../../../../../"); // Adjust based on project structure
 
-  const updateStdout = getStdoutUpdater();
+  // current scope name
+  const oldScope = "@repo/";
 
-  function replaceInFile(filePath: string) {
-    updateStdout("file : ", filePath);
-    const content = fs.readFileSync(filePath, "utf-8");
-    const updatedContent = content.replace(
-      new RegExp(oldScope, "g"),
-      targetScope,
-    );
-    fs.writeFileSync(filePath, updatedContent, "utf-8");
-  }
+  // new scope name
+  const targetScope = `@${name}/`;
 
-  function processDirectory(directory: string) {
-    const entries = fs.readdirSync(directory, { withFileTypes: true });
-    for (const entry of entries) {
-      const fullPath = path.join(directory, entry.name);
-      const ext = path.extname(entry.name);
-      if (entry.isDirectory() && !EXCLUDE_DIRS.includes(entry.name)) {
-        processDirectory(fullPath);
-      } else if (
-        entry.isFile() &&
-        TARGET_EXTENSIONS.some((target) => ext.endsWith(target)) &&
-        fullPath !== __filename
-      ) {
-        replaceInFile(fullPath);
-      }
-    }
-  }
-
-  updateStdout("file : ", __filename);
-  updateStdout("rootDir : ", rootDir);
-  processDirectory(rootDir);
-  updateStdout.done();
+  // replace all occurrences of the old scope with the new scope
+  replaceAllInDirectory(rootDir, oldScope, targetScope);
 }

--- a/tools/cli/src/utils/escapeRegExp/index.ts
+++ b/tools/cli/src/utils/escapeRegExp/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Escape special characters in a string for use in a regular expression.
+ *
+ * @param string - The string to escape.
+ */
+export default function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/tools/cli/src/utils/replaceAllInDirectory/index.ts
+++ b/tools/cli/src/utils/replaceAllInDirectory/index.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import getStdoutUpdater from "../getStdoutUpdater";
+import replaceInFile from "../replaceInFile";
 
 /**
  * Renames the scope of a package name in each file with the specified extension
@@ -39,15 +40,7 @@ export default function replaceAllInDirectory(
 ) {
   const updateStdout = getStdoutUpdater();
 
-  function replaceInFile(filePath: string) {
-    updateStdout("file : ", filePath);
-    const content = fs.readFileSync(filePath, "utf-8");
-    const updatedContent = content.replace(
-      new RegExp(oldString, "g"),
-      newString,
-    );
-    fs.writeFileSync(filePath, updatedContent, "utf-8");
-  }
+  updateStdout("rootDir : ", rootDir);
 
   function processDirectory(directory: string) {
     const entries = fs.readdirSync(directory, { withFileTypes: true });
@@ -61,12 +54,11 @@ export default function replaceAllInDirectory(
         TARGET_EXTENSIONS.some((target) => ext.endsWith(target)) &&
         fullPath !== __filename
       ) {
-        replaceInFile(fullPath);
+        replaceInFile(fullPath, oldString, newString);
       }
     }
   }
 
-  updateStdout("rootDir : ", rootDir);
   processDirectory(rootDir);
   updateStdout.done();
 }

--- a/tools/cli/src/utils/replaceAllInDirectory/index.ts
+++ b/tools/cli/src/utils/replaceAllInDirectory/index.ts
@@ -32,11 +32,17 @@ const EXCLUDE_DIRS = [
  * @param rootDir
  * @param oldString
  * @param newString
+ * @param excludeDirs
+ * @param targetExtensions
  */
 export default function replaceAllInDirectory(
   rootDir: string,
   oldString: string,
   newString: string,
+  { excludeDirs, targetExtensions } = {
+    excludeDirs: EXCLUDE_DIRS,
+    targetExtensions: TARGET_EXTENSIONS,
+  },
 ) {
   const updateStdout = getStdoutUpdater();
 
@@ -47,11 +53,11 @@ export default function replaceAllInDirectory(
     for (const entry of entries) {
       const fullPath = path.join(directory, entry.name);
       const ext = path.extname(entry.name);
-      if (entry.isDirectory() && !EXCLUDE_DIRS.includes(entry.name)) {
+      if (entry.isDirectory() && !excludeDirs.includes(entry.name)) {
         processDirectory(fullPath);
       } else if (
         entry.isFile() &&
-        TARGET_EXTENSIONS.some((target) => ext.endsWith(target)) &&
+        targetExtensions.some((target) => ext.endsWith(target)) &&
         fullPath !== __filename
       ) {
         replaceInFile(fullPath, oldString, newString);

--- a/tools/cli/src/utils/replaceAllInDirectory/index.ts
+++ b/tools/cli/src/utils/replaceAllInDirectory/index.ts
@@ -48,7 +48,7 @@ export default function replaceAllInDirectory(
 
   updateStdout("rootDir : ", rootDir);
 
-  function processDirectory(directory: string) {
+  (function processDirectory(directory: string) {
     const entries = fs.readdirSync(directory, { withFileTypes: true });
     for (const entry of entries) {
       const fullPath = path.join(directory, entry.name);
@@ -63,8 +63,7 @@ export default function replaceAllInDirectory(
         replaceInFile(fullPath, oldString, newString);
       }
     }
-  }
+  })(rootDir);
 
-  processDirectory(rootDir);
   updateStdout.done();
 }

--- a/tools/cli/src/utils/replaceAllInDirectory/index.ts
+++ b/tools/cli/src/utils/replaceAllInDirectory/index.ts
@@ -1,0 +1,72 @@
+import fs from "fs";
+import path from "path";
+import getStdoutUpdater from "../getStdoutUpdater";
+
+/**
+ * Renames the scope of a package name in each file with the specified extension
+ */
+const TARGET_EXTENSIONS = ["md", "json", "css", "ts", "tsx", "js", "jsx"];
+
+/**
+ * Directories to exclude from renaming
+ */
+const EXCLUDE_DIRS = [
+  "node_modules",
+  ".git",
+  ".devcontainer",
+  ".github",
+  ".husky",
+  ".idea",
+  ".turbo",
+  ".vscode",
+  ".next",
+  "dist",
+  "build",
+  "out",
+  "storybook-static",
+];
+
+/**
+ *
+ * @param rootDir
+ * @param oldString
+ * @param newString
+ */
+export default function replaceAllInDirectory(
+  rootDir: string,
+  oldString: string,
+  newString: string,
+) {
+  const updateStdout = getStdoutUpdater();
+
+  function replaceInFile(filePath: string) {
+    updateStdout("file : ", filePath);
+    const content = fs.readFileSync(filePath, "utf-8");
+    const updatedContent = content.replace(
+      new RegExp(oldString, "g"),
+      newString,
+    );
+    fs.writeFileSync(filePath, updatedContent, "utf-8");
+  }
+
+  function processDirectory(directory: string) {
+    const entries = fs.readdirSync(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(directory, entry.name);
+      const ext = path.extname(entry.name);
+      if (entry.isDirectory() && !EXCLUDE_DIRS.includes(entry.name)) {
+        processDirectory(fullPath);
+      } else if (
+        entry.isFile() &&
+        TARGET_EXTENSIONS.some((target) => ext.endsWith(target)) &&
+        fullPath !== __filename
+      ) {
+        replaceInFile(fullPath);
+      }
+    }
+  }
+
+  updateStdout("rootDir : ", rootDir);
+  processDirectory(rootDir);
+  updateStdout.done();
+}

--- a/tools/cli/src/utils/replaceAllInDirectory/index.ts
+++ b/tools/cli/src/utils/replaceAllInDirectory/index.ts
@@ -28,12 +28,13 @@ const EXCLUDE_DIRS = [
 ];
 
 /**
+ * Recursively replaces all occurrences of a string in files with the specified extensions
  *
- * @param rootDir
- * @param oldString
- * @param newString
- * @param excludeDirs
- * @param targetExtensions
+ * @param rootDir - The root directory to start the search
+ * @param oldString - The string to be replaced
+ * @param newString - The string to replace with
+ * @param excludeDirs - Directories to exclude from the search
+ * @param targetExtensions - File extensions to target for replacement
  */
 export default function replaceAllInDirectory(
   rootDir: string,

--- a/tools/cli/src/utils/replaceInFile/index.ts
+++ b/tools/cli/src/utils/replaceInFile/index.ts
@@ -1,0 +1,17 @@
+import fs from "fs";
+
+/**
+ *
+ * @param filePath
+ * @param oldString
+ * @param newString
+ */
+export default function replaceInFile(
+  filePath: string,
+  oldString: string,
+  newString: string,
+) {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const updatedContent = content.replace(new RegExp(oldString, "g"), newString);
+  fs.writeFileSync(filePath, updatedContent, "utf-8");
+}

--- a/tools/cli/src/utils/replaceInFile/index.ts
+++ b/tools/cli/src/utils/replaceInFile/index.ts
@@ -1,10 +1,11 @@
 import fs from "fs";
 
 /**
+ * Replaces all occurrences of a string in a file with another string
  *
- * @param filePath
- * @param oldString
- * @param newString
+ * @param filePath - The path to the file
+ * @param oldString - The string to be replaced
+ * @param newString - The string to replace with
  */
 export default function replaceInFile(
   filePath: string,

--- a/tools/cli/src/utils/replaceInFile/index.ts
+++ b/tools/cli/src/utils/replaceInFile/index.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import escapeRegExp from "../escapeRegExp";
 
 /**
  * Replaces all occurrences of a string in a file with another string
@@ -13,6 +14,10 @@ export default function replaceInFile(
   newString: string,
 ) {
   const content = fs.readFileSync(filePath, "utf-8");
-  const updatedContent = content.replace(new RegExp(oldString, "g"), newString);
+  const escapedOldString = escapeRegExp(oldString);
+  const updatedContent = content.replace(
+    new RegExp(escapedOldString, "g"),
+    newString,
+  );
   fs.writeFileSync(filePath, updatedContent, "utf-8");
 }


### PR DESCRIPTION
This pull request introduces three new CLI tools (`change-owner-name`, `rename-repository`, and `rename-scope`) to the `tools/cli` package, along with shared utility functions for file and directory manipulation. These tools allow users to perform bulk text replacements in a codebase, such as changing owner IDs, repository names, or package scopes. The most important changes include adding the CLI commands, implementing their core logic, and creating reusable utilities.

### New CLI Commands

* **`change-owner-name`**: A CLI tool to replace all occurrences of a specific owner ID in the codebase with a new owner name. The command is implemented in `tools/cli/src/change-owner-name/index.ts` and uses the `replaceAllInDirectory` utility. [[1]](diffhunk://#diff-dc0e39c6c6c7055d299637a995ef8738a7c2a1c1611b569ad6fb8555440d9411R1-R29) [[2]](diffhunk://#diff-a37e9591aa93f56feeaa2017b7a02a84f826edd663db58572e5f4e032b3dedffR1-R18)
* **`rename-repository`**: A CLI tool to rename the repository by replacing all instances of the current repository name with a new name. The command is implemented in `tools/cli/src/rename-repository/index.ts` and retrieves the current name from `package.json`. [[1]](diffhunk://#diff-655eabb09d7f0c7ad84c509e01eebba4a13683867f3b5d3e1f9f7da66c8d36e6R1-R29) [[2]](diffhunk://#diff-4dd335a9a74a65c2c4e02f71a7a0c7d4fa5f953fc205f3d705ab4369712c4dd6R1-R23)
* **`rename-scope`**: A CLI tool to change the package scope (e.g., `@repo/`) throughout the codebase. The command is implemented in `tools/cli/src/rename-scope/renameScope/index.ts` and uses the `replaceAllInDirectory` utility for replacements.

### Shared Utilities

* **`replaceAllInDirectory`**: A utility function to recursively replace text in files of specified extensions, with support for excluding certain directories. This function is used by all three CLI tools.
* **`replaceInFile`**: A helper function to replace all occurrences of a string in a single file. It is utilized by `replaceAllInDirectory`.

### Documentation and Configuration Updates

* **Documentation**: Updated `tools/cli/README.md` to include usage instructions for the new commands. [[1]](diffhunk://#diff-841b5ad1eb96f381373e821f7ef413827a8060d2e96777de901dc7f24013c912R13-R18) [[2]](diffhunk://#diff-841b5ad1eb96f381373e821f7ef413827a8060d2e96777de901dc7f24013c912R58-R93)
* **Configuration**: Added new CLI commands to the `bin` section of `tools/cli/package.json` for proper registration.