### PR TITLE
빌드 설정에서 moduleResolution 관련 warning 이 발생하는 패키지들에 대한 빌드 설정 변경

### DIFF
--- a/packages/browser-utils/tsconfig.json
+++ b/packages/browser-utils/tsconfig.json
@@ -21,6 +21,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/browser-utils/vite.config.ts
+++ b/packages/browser-utils/vite.config.ts
@@ -6,7 +6,7 @@ import tsConfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [dtsPlugin(), tsConfigPaths()],
+  plugins: [dtsPlugin({ include: ["src"] }), tsConfigPaths()],
   build: {
     emptyOutDir: false,
     lib: {

--- a/packages/node-utils/tsconfig.json
+++ b/packages/node-utils/tsconfig.json
@@ -26,6 +26,5 @@
       "@/*": ["./src/*"],
     }
   },
-  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/node-utils/vite.config.ts
+++ b/packages/node-utils/vite.config.ts
@@ -6,7 +6,7 @@ import tsConfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [dtsPlugin(), tsConfigPaths()],
+  plugins: [dtsPlugin({ include: ["src"] }), tsConfigPaths()],
   build: {
     ssr: true,
     emptyOutDir: false,

--- a/packages/react-ui/tsconfig.json
+++ b/packages/react-ui/tsconfig.json
@@ -30,6 +30,5 @@
       "@repo/react-ui/*": ["./src/*"],
     }
   },
-  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -60,10 +60,13 @@ export default defineConfig({
          * @param chunkInfo - Information about the chunk being processed.
          */
         assetFileNames: (chunkInfo) => {
-          if (chunkInfo.name === "react-ui.css") {
+          if (chunkInfo.names.includes("react-ui.css")) {
             return "styles/base.css";
           }
-          return chunkInfo.name;
+          if (chunkInfo.names[0]) {
+            return chunkInfo.names[0];
+          }
+          throw new Error("No name found for chunkInfo");
         },
       },
     },

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -71,7 +71,7 @@ export default defineConfig({
           if (chunkInfo.names[0]) {
             return chunkInfo.names[0];
           }
-          throw new Error("No name found for chunkInfo");
+          throw new Error(`No name found for chunkInfo. Details: names=${JSON.stringify(chunkInfo.names)}, fileName=${chunkInfo.fileName}, type=${chunkInfo.type}`);
         },
       },
     },

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -33,7 +33,12 @@ const fileName: Exclude<LibraryOptions["fileName"], string> = (
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [dtsPlugin(), react(), tsConfigPaths(), tailwindcss()],
+  plugins: [
+    dtsPlugin({ include: ["src"] }),
+    react(),
+    tsConfigPaths(),
+    tailwindcss(),
+  ],
   build: {
     emptyOutDir: false,
     lib: {

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -71,7 +71,9 @@ export default defineConfig({
           if (chunkInfo.names[0]) {
             return chunkInfo.names[0];
           }
-          throw new Error(`No name found for chunkInfo. Details: names=${JSON.stringify(chunkInfo.names)}, fileName=${chunkInfo.fileName}, type=${chunkInfo.type}`);
+          throw new Error(
+            `No name found for chunkInfo. Details: ${JSON.stringify(chunkInfo)}`,
+          );
         },
       },
     },

--- a/packages/react-utils/tsconfig.json
+++ b/packages/react-utils/tsconfig.json
@@ -23,6 +23,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/react-utils/vite.config.ts
+++ b/packages/react-utils/vite.config.ts
@@ -8,7 +8,12 @@ import { preserveDirective } from "rollup-preserve-directives";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [dtsPlugin(), react(), tsConfigPaths(), preserveDirective()],
+  plugins: [
+    dtsPlugin({ include: ["src"] }),
+    react(),
+    tsConfigPaths(),
+    preserveDirective(),
+  ],
   build: {
     emptyOutDir: false,
     lib: {

--- a/tools/playwright-web/tsconfig.json
+++ b/tools/playwright-web/tsconfig.json
@@ -3,6 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["tests"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This pull request refines TypeScript configuration and Vite plugin setups across multiple packages to improve consistency and maintainability. The key changes include removing redundant `include` entries in `tsconfig.json` files and updating the `dtsPlugin` configuration in `vite.config.ts` files to explicitly include the `src` directory.

### TypeScript Configuration Updates:
* Removed the `"include": ["src"]` entry from `tsconfig.json` files in the following packages, as it is redundant given the default behavior of TypeScript:
  - `packages/browser-utils`
  - `packages/node-utils`
  - `packages/react-ui`
  - `packages/react-utils`
  - `tools/playwright-web`

### Vite Plugin Configuration Updates:
* Updated `vite.config.ts` files to configure `dtsPlugin` with an explicit `include: ["src"]` option for better clarity:
  - `packages/browser-utils`
  - `packages/node-utils`
  - `packages/react-ui`
  - `packages/react-utils`

### Additional Improvements:
* Refined the `assetFileNames` logic in `packages/react-ui/vite.config.ts` to handle chunk names more robustly and throw an error if no name is found.