### PR TITLE
vitest 실행 결과 coverage 집계 대상에서 제외할 exclude 목록 설정

### DIFF
--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -1,10 +1,27 @@
-import { mergeConfig, defineProject } from "vitest/config";
+import { mergeConfig, defineProject, defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 import uiTestConfig from "@repo/vitest-config/ui";
 
 export default mergeConfig(
-  uiTestConfig,
+  mergeConfig(
+    uiTestConfig,
+    defineConfig({
+      test: {
+        coverage: {
+          provider: "v8",
+          exclude: [
+            "next.config.js",
+            "vitest.config.mts",
+            "eslint.config.js",
+            ".next",
+            "configs/**",
+            "public/**",
+          ],
+        },
+      },
+    }),
+  ),
   defineProject({
     plugins: [tsconfigPaths(), react()],
     test: { setupFiles: ["./tests/setup.ts"] },

--- a/packages/browser-utils/src/dom/index.ts
+++ b/packages/browser-utils/src/dom/index.ts
@@ -1,1 +1,3 @@
+/* v8 ignore start */
 export { default as alertHelloWorld } from "./alertHelloWorld";
+/* v8 ignore stop */

--- a/packages/browser-utils/src/msw/index.ts
+++ b/packages/browser-utils/src/msw/index.ts
@@ -1,1 +1,3 @@
+/* v8 ignore start */
 export { default as initMockWorker } from "./initMockWorker";
+/* v8 ignore stop */

--- a/packages/browser-utils/src/string/index.ts
+++ b/packages/browser-utils/src/string/index.ts
@@ -1,1 +1,3 @@
+/* v8 ignore start */
 export { default as isEmptyString } from "./isEmptyString";
+/* v8 ignore stop */

--- a/packages/node-utils/src/fs/index.ts
+++ b/packages/node-utils/src/fs/index.ts
@@ -1,1 +1,3 @@
+/* v8 ignore start */
 export { default as ls } from "./ls";
+/* v8 ignore stop */

--- a/packages/node-utils/src/misc/index.ts
+++ b/packages/node-utils/src/misc/index.ts
@@ -1,1 +1,3 @@
+/* v8 ignore start */
 export { default as isInNodeRuntime } from "./isInNodeRuntime";
+/* v8 ignore stop */

--- a/packages/node-utils/src/msw/index.ts
+++ b/packages/node-utils/src/msw/index.ts
@@ -1,1 +1,3 @@
+/* v8 ignore start */
 export { default as initMockServer } from "./initMockServer";
+/* v8 ignore stop */

--- a/packages/react-ui/src/base/shadcn-ui/index.ts
+++ b/packages/react-ui/src/base/shadcn-ui/index.ts
@@ -1,3 +1,7 @@
+/* v8 ignore start */
+
 /* Button 컴포넌트 */
 export { buttonVariants } from "@/base/shadcn-ui/buttonVariants";
 export { Button } from "@/base/shadcn-ui/button";
+
+/* v8 ignore stop */

--- a/packages/react-ui/src/components/index.ts
+++ b/packages/react-ui/src/components/index.ts
@@ -1,2 +1,6 @@
+/* v8 ignore start */
+
 /* SampleButton */
 export { default as SampleButton } from "@/components/SampleButton";
+
+/* v8 ignore stop */

--- a/packages/react-ui/src/styles/index.ts
+++ b/packages/react-ui/src/styles/index.ts
@@ -1,2 +1,4 @@
+/* v8 ignore start */
 /* base 스타일 - TailwindCSS 빌드를 위한 entry point 역할 */
 import "@/styles/base.css";
+/* v8 ignore stop */

--- a/packages/react-utils/src/hocs/index.ts
+++ b/packages/react-utils/src/hocs/index.ts
@@ -1,1 +1,3 @@
+/* v8 ignore start */
 export { default as withHelloWorld } from "./withHelloWorld";
+/* v8 ignore stop */

--- a/packages/react-utils/src/hooks/index.ts
+++ b/packages/react-utils/src/hooks/index.ts
@@ -1,1 +1,3 @@
+/* v8 ignore start */
 export { default as useInterval } from "./useInterval";
+/* v8 ignore stop */

--- a/packages/react-utils/src/providers/index.ts
+++ b/packages/react-utils/src/providers/index.ts
@@ -1,1 +1,3 @@
+/* v8 ignore start */
 export { default as MSWProvider } from "./MSWProvider";
+/* v8 ignore stop */


### PR DESCRIPTION
This pull request introduces two main changes: adding test coverage configuration to the Vitest setup and marking exports in multiple files to be ignored by the v8 coverage tool. These updates improve test coverage management and ensure certain exports are excluded from coverage calculations.

### Test Coverage Configuration:

* [`apps/web/vitest.config.mts`](diffhunk://#diff-82544e703c2be573619a66b2de9b4e1f4eeae9f00fb7f6c09e0bdc788c51b912L1-R24): Added a nested `defineConfig` call to configure test coverage with the v8 provider and exclude specific files and directories (e.g., `next.config.js`, `.next`, `public/**`) from coverage reports.

### v8 Coverage Ignore Markers:

* Added `/* v8 ignore start */` and `/* v8 ignore stop */` around exports in the following files to exclude them from v8 coverage:
  - [`packages/browser-utils/src/dom/index.ts`](diffhunk://#diff-41d44224c70bfef43bb73c926a349d54a52626913c5d7ea19c4e1112d12c3c26R1-R3): Ignored the export of `alertHelloWorld`.
  - [`packages/browser-utils/src/msw/index.ts`](diffhunk://#diff-0a7145ea1dc780aaed91f2339274c2f8d66a4359922f0c811e0363ab74b7f214R1-R3): Ignored the export of `initMockWorker`.
  - [`packages/browser-utils/src/string/index.ts`](diffhunk://#diff-53974de3de351fa1b2410a032ae2c500d4e877545b00285df3371726345bf402R1-R3): Ignored the export of `isEmptyString`.
  - [`packages/node-utils/src/fs/index.ts`](diffhunk://#diff-e15a2d0d9a820daf0d6350cdb8928ebe23ca11d436fe2b59f63f6425c83249a6R1-R3): Ignored the export of `ls`.
  - [`packages/node-utils/src/misc/index.ts`](diffhunk://#diff-4b88f4cf3773fb7799c946de6e06df009da7db6db84d46393e5207dcb9881bb3R1-R3): Ignored the export of `isInNodeRuntime`.
  - [`packages/node-utils/src/msw/index.ts`](diffhunk://#diff-c8d4a28f373c3fdce37129f3d810d48ec8c5a9fd1463fda033d48167201435eeR1-R3): Ignored the export of `initMockServer`.
  - [`packages/react-ui/src/base/shadcn-ui/index.ts`](diffhunk://#diff-39ddd8248e8fcc43b30bcb30430db1b4737a8a6eb2586eaf8e4a279f74a2528cR1-R7): Ignored the exports of `buttonVariants` and `Button`.
  - [`packages/react-ui/src/components/index.ts`](diffhunk://#diff-15b80d762541e4d24bc9c26cf06ad9c5d1dc57935de3c476995ea6c66e848bdbR1-R6): Ignored the export of `SampleButton`.
  - [`packages/react-ui/src/styles/index.ts`](diffhunk://#diff-08c8cb9957e2a050329771cfc7a0d6939fe7b6762cd689452064ef5448b0364eR1-R4): Ignored the import of `base.css`.
  - [`packages/react-utils/src/hocs/index.ts`](diffhunk://#diff-24ac2993ce759b0d0b10f3fac711367a0412e317cf8dab9d244ca81fe9c07ee0R1-R3): Ignored the export of `withHelloWorld`.
  - [`packages/react-utils/src/hooks/index.ts`](diffhunk://#diff-30975e553464b6439bf1ceef289c6c5f07d6ecb63aa5759cca3fb7b6cb83bb0fR1-R3): Ignored the export of `useInterval`.
  - [`packages/react-utils/src/providers/index.ts`](diffhunk://#diff-5c4d99a2703d1fc09563a23e22922317e6debe710b4cd4cc5dd1a96b7edb257dR1-R3): Ignored the export of `MSWProvider`.