### PR TITLE
TS 에러가 있는 일부 `vitest.config.ts` 파일들의 에러 사항 수정

### DIFF
--- a/apps/frontend-workshop/vitest.workspace.ts
+++ b/apps/frontend-workshop/vitest.workspace.ts
@@ -8,7 +8,8 @@ import { storybookTest } from "@storybook/experimental-addon-test/vitest-plugin"
 const workspaceDirname =
   typeof __dirname !== "undefined"
     ? __dirname
-    : dirname(fileURLToPath(import.meta.url));
+    : //  @ts-expect-error TS1343 fixme: tsconfig 의 module 속성을 수정하는 방향으로 해결해야 함
+      dirname(fileURLToPath(import.meta.url));
 
 // More info at: https://storybook.js.org/docs/writing-tests/test-addon
 export default defineWorkspace([

--- a/apps/frontend-workshop/vitest.workspace.ts
+++ b/apps/frontend-workshop/vitest.workspace.ts
@@ -8,8 +8,7 @@ import { storybookTest } from "@storybook/experimental-addon-test/vitest-plugin"
 const workspaceDirname =
   typeof __dirname !== "undefined"
     ? __dirname
-    : //  @ts-expect-error TS1343 fixme: tsconfig 의 module 속성을 수정하는 방향으로 해결해야 함
-      dirname(fileURLToPath(import.meta.url));
+    : dirname(fileURLToPath(import.meta.url));
 
 // More info at: https://storybook.js.org/docs/writing-tests/test-addon
 export default defineWorkspace([

--- a/apps/frontend-workshop/vitest.workspace.ts
+++ b/apps/frontend-workshop/vitest.workspace.ts
@@ -1,14 +1,14 @@
-import path from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { defineWorkspace } from "vitest/config";
 
 import { storybookTest } from "@storybook/experimental-addon-test/vitest-plugin";
 
-const dirname =
+const workspaceDirname =
   typeof __dirname !== "undefined"
     ? __dirname
-    : path.dirname(fileURLToPath(import.meta.url));
+    : dirname(fileURLToPath(import.meta.url));
 
 // More info at: https://storybook.js.org/docs/writing-tests/test-addon
 export default defineWorkspace([
@@ -18,7 +18,7 @@ export default defineWorkspace([
     plugins: [
       // The plugin will run tests for the stories defined in your Storybook config
       // See options at: https://storybook.js.org/docs/writing-tests/test-addon#storybooktest
-      storybookTest({ configDir: path.join(dirname, ".storybook") }),
+      storybookTest({ configDir: join(workspaceDirname, ".storybook") }),
     ],
     test: {
       name: "frontend-workshop",

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
           provider: "v8",
           exclude: [
             "next.config.js",
-            "vitest.config.mts",
+            "vitest.config.ts",
             "eslint.config.js",
             ".next",
             "configs/**",


### PR DESCRIPTION
This pull request includes updates to the Vitest configuration files for two projects (`frontend-workshop` and `web`) to improve maintainability and align with updated file naming conventions. The changes primarily involve refactoring path handling and updating file references.

### Updates to path handling:
* [`apps/frontend-workshop/vitest.workspace.ts`](diffhunk://#diff-cf5ea9123cc10329f8085649405e4594db8e5bc99acc75843adf5675c17692ecL1-R11): Replaced the use of `path` with destructured imports (`dirname` and `join`) from `node:path` and renamed the `dirname` constant to `workspaceDirname` for clarity. Updated the `storybookTest` plugin configuration to use `join(workspaceDirname, ".storybook")` instead of `path.join(dirname, ".storybook")`. [[1]](diffhunk://#diff-cf5ea9123cc10329f8085649405e4594db8e5bc99acc75843adf5675c17692ecL1-R11) [[2]](diffhunk://#diff-cf5ea9123cc10329f8085649405e4594db8e5bc99acc75843adf5675c17692ecL21-R21)

### Updates to file references:
* `apps/web/vitest.config.ts` (renamed from `apps/web/vitest.config.mts`): Updated the Vitest configuration to exclude `vitest.config.ts` instead of the old `vitest.config.mts` file, reflecting the file name change.