### PR TITLE
패키지들에 외부 번들러에 의한 코드 스플리팅 지원을 추가

### DIFF
--- a/.github/workflows/install-and-build.yml
+++ b/.github/workflows/install-and-build.yml
@@ -21,6 +21,7 @@ jobs:
             tools/*/.turbo
             packages/*/.turbo
             configs/*/.turbo
+            shared/*/.turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-
@@ -39,6 +40,7 @@ jobs:
             tools/*/node_modules
             packages/*/node_modules
             configs/*/node_modules
+            shared/*/node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/pnpm-lock.yaml', '**/pnpm-workspace.yaml') }}
           restore-keys: |
             ${{ runner.os }}-node-modules-
@@ -61,6 +63,7 @@ jobs:
             tools/*/.turbo
             packages/*/.turbo
             configs/*/.turbo
+            shared/*/.turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
       - name: Use Node.js 22.x
         uses: actions/setup-node@v4
@@ -76,6 +79,7 @@ jobs:
             tools/*/node_modules
             packages/*/node_modules
             configs/*/node_modules
+            shared/*/node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/pnpm-lock.yaml', '**/pnpm-workspace.yaml') }}
       - name: Cache dist directories
         id: cache-dist
@@ -87,6 +91,7 @@ jobs:
             apps/*/storybook-static
             packages/*/dist
             configs/*/dist
+            shared/*/dist
           key: ${{ runner.os }}-dist-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-dist-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
             tools/*/.turbo
             packages/*/.turbo
             configs/*/.turbo
+            shared/*/.turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
 
       - name: Restore node_modules cache
@@ -44,6 +45,7 @@ jobs:
             tools/*/node_modules
             packages/*/node_modules
             configs/*/node_modules
+            shared/*/node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/pnpm-lock.yaml', '**/pnpm-workspace.yaml') }}
 
       - name: Cache dist directories
@@ -55,6 +57,7 @@ jobs:
             apps/*/storybook-static
             packages/*/dist
             configs/*/dist
+            shared/*/dist
           key: ${{ runner.os }}-dist-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-dist-

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -107,6 +107,7 @@ jobs:
             tools/*/.turbo
             packages/*/.turbo
             configs/*/.turbo
+            shared/*/.turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
       - name: Use Node.js 22.x
         uses: actions/setup-node@v4
@@ -122,6 +123,7 @@ jobs:
             tools/*/node_modules
             packages/*/node_modules
             configs/*/node_modules
+            shared/*/node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/pnpm-lock.yaml', '**/pnpm-workspace.yaml') }}
       - name: Restore dist cache
         uses: actions/cache@v3
@@ -132,6 +134,7 @@ jobs:
             apps/*/storybook-static
             packages/*/dist
             configs/*/dist
+            shared/*/dist
           key: ${{ runner.os }}-dist-${{ github.sha }}
       - run: pnpm run test
       - run: pnpm run merge-json-reports

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -35,6 +35,7 @@
   ],
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
+    "@repo/helpers": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@repo/vitest-config": "workspace:*",
     "@testing-library/dom": "^10.4.0",

--- a/packages/browser-utils/vite.config.ts
+++ b/packages/browser-utils/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vite";
 import { resolve } from "path";
 import dtsPlugin from "vite-plugin-dts";
 import tsConfigPaths from "vite-tsconfig-paths";
+import { runWithGlob } from "@repo/helpers/runWithGlob";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -11,11 +12,18 @@ export default defineConfig({
     emptyOutDir: false,
     lib: {
       name: "browser-utils",
-      entry: {
-        string: resolve(__dirname, "src/string/index.ts"),
-        dom: resolve(__dirname, "src/dom/index.ts"),
-        msw: resolve(__dirname, "src/msw/index.ts"),
-      },
+      entry: Object.fromEntries(
+        runWithGlob(
+          "src/**/*.{ts,tsx}",
+          (file) => [
+            // 엔트리 이름
+            file.replace(/^src\//, "").replace(/index\.(ts|tsx)$/, ""),
+            // 절대 경로
+            resolve(__dirname, file),
+          ],
+          ["src/**/*.{d,spec}.ts"],
+        ),
+      ),
       formats: ["es", "cjs"],
       fileName: (format, entryName) => `${entryName}/index.${format}.js`,
     },

--- a/packages/http-clients/package.json
+++ b/packages/http-clients/package.json
@@ -32,6 +32,7 @@
   ],
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
+    "@repo/helpers": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@types/node": "^22.13.10",
     "eslint": "^9.23.0",

--- a/packages/http-clients/tsconfig.json
+++ b/packages/http-clients/tsconfig.json
@@ -26,6 +26,5 @@
       "@/*": ["./src/*"],
     }
   },
-  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/http-clients/vite.config.ts
+++ b/packages/http-clients/vite.config.ts
@@ -2,19 +2,27 @@ import { defineConfig } from "vite";
 import { resolve } from "path";
 import dtsPlugin from "vite-plugin-dts";
 import tsConfigPaths from "vite-tsconfig-paths";
+import { runWithGlob } from "@repo/helpers/runWithGlob";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [dtsPlugin(), tsConfigPaths()],
+  plugins: [dtsPlugin({ include: ["src"] }), tsConfigPaths()],
   build: {
     emptyOutDir: false,
     lib: {
       name: "http-clients",
-      entry: {
-        instances: resolve(__dirname, "src/instances/index.ts"),
-        mocks: resolve(__dirname, "src/mocks/index.ts"),
-        types: resolve(__dirname, "src/types/index.ts"),
-      },
+      entry: Object.fromEntries(
+        runWithGlob(
+          "src/**/*.{ts,tsx}",
+          (file) => [
+            // 엔트리 이름
+            file.replace(/^src\//, "").replace(/index\.(ts|tsx)$/, ""),
+            // 절대 경로
+            resolve(__dirname, file),
+          ],
+          ["src/**/*.{d,spec}.ts"],
+        ),
+      ),
       formats: ["es", "cjs"],
       fileName: (format, entryName) => `${entryName}/index.${format}.js`,
     },

--- a/packages/node-utils/package.json
+++ b/packages/node-utils/package.json
@@ -40,6 +40,7 @@
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@repo/vitest-config": "workspace:*",
+    "@repo/helpers": "workspace:*",
     "@types/node": "^22.13.10",
     "@vitest/coverage-v8": "^3.1.1",
     "eslint": "^9.23.0",

--- a/packages/node-utils/vite.config.ts
+++ b/packages/node-utils/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vite";
 import { resolve } from "path";
 import dtsPlugin from "vite-plugin-dts";
 import tsConfigPaths from "vite-tsconfig-paths";
+import { runWithGlob } from "@repo/helpers/runWithGlob";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -11,11 +12,18 @@ export default defineConfig({
     ssr: true,
     emptyOutDir: false,
     rollupOptions: {
-      input: {
-        fs: resolve(__dirname, "src/fs/index.ts"),
-        msw: resolve(__dirname, "src/msw/index.ts"),
-        misc: resolve(__dirname, "src/misc/index.ts"),
-      },
+      input: Object.fromEntries(
+        runWithGlob(
+          "src/**/*.{ts,tsx}",
+          (file) => [
+            // 엔트리 이름
+            file.replace(/^src\//, "").replace(/index\.(ts|tsx)$/, ""),
+            // 절대 경로
+            resolve(__dirname, file),
+          ],
+          ["src/**/*.{d,spec}.ts"],
+        ),
+      ),
       output: [
         {
           format: "es",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
+    "@repo/helpers": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@repo/vitest-config": "workspace:*",
     "@storybook/react": "^8.6.11",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -34,6 +34,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": ["**/*.css"],
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -32,6 +32,14 @@ const fileName: Exclude<LibraryOptions["fileName"], string> = (
   }
 };
 
+/**
+ * Predefined mappings for specific entry points to their corresponding names.
+ */
+const predefinedMappings = new Map([
+  ["src/base/shadcn-ui/index.ts", "shadcn-ui"],
+  ["src/lib/utils.ts", "utils"],
+]);
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
@@ -44,25 +52,27 @@ export default defineConfig({
     emptyOutDir: false,
     lib: {
       name: "react-ui",
-      // entry: {
-      //   "shadcn-ui": resolve(__dirname, "src/base/shadcn-ui/index.ts"),
-      //   utils: resolve(__dirname, "src/lib/utils.ts"),
-      //   components: resolve(__dirname, "src/components/index.ts"),
-      //   styles: resolve(__dirname, "src/styles/index.ts"),
-      // },
       entry: Object.fromEntries(
         runWithGlob(
           "src/**/*.{ts,tsx}",
           (file) => [
             // 엔트리 이름
             (function nameMapping() {
-              if (file === "src/base/shadcn-ui/index.ts") {
-                return "shadcn-ui";
+              if (predefinedMappings.has(file)) {
+                return predefinedMappings.get(file);
               }
-              if (file === "src/lib/utils.ts") {
-                return "utils";
+
+              const fallbackName = file
+                .replace(/^src\//, "")
+                .replace(/index\.(ts|tsx)$/, "");
+
+              if (!fallbackName) {
+                throw new Error(
+                  `Invalid entry name generated for file: ${file}`,
+                );
               }
-              return file.replace(/^src\//, "").replace(/index\.(ts|tsx)$/, "");
+
+              return fallbackName;
             })(),
             // 절대 경로
             resolve(__dirname, file),

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -5,6 +5,7 @@ import react from "@vitejs/plugin-react";
 import dtsPlugin from "vite-plugin-dts";
 import tsConfigPaths from "vite-tsconfig-paths";
 import tailwindcss from "@tailwindcss/vite";
+import { runWithGlob } from "@repo/helpers/runWithGlob";
 
 /**
  * Generates the file name for the library based on the format and entry name.
@@ -43,12 +44,32 @@ export default defineConfig({
     emptyOutDir: false,
     lib: {
       name: "react-ui",
-      entry: {
-        "shadcn-ui": resolve(__dirname, "src/base/shadcn-ui/index.ts"),
-        utils: resolve(__dirname, "src/lib/utils.ts"),
-        components: resolve(__dirname, "src/components/index.ts"),
-        styles: resolve(__dirname, "src/styles/index.ts"),
-      },
+      // entry: {
+      //   "shadcn-ui": resolve(__dirname, "src/base/shadcn-ui/index.ts"),
+      //   utils: resolve(__dirname, "src/lib/utils.ts"),
+      //   components: resolve(__dirname, "src/components/index.ts"),
+      //   styles: resolve(__dirname, "src/styles/index.ts"),
+      // },
+      entry: Object.fromEntries(
+        runWithGlob(
+          "src/**/*.{ts,tsx}",
+          (file) => [
+            // 엔트리 이름
+            (function nameMapping() {
+              if (file === "src/base/shadcn-ui/index.ts") {
+                return "shadcn-ui";
+              }
+              if (file === "src/lib/utils.ts") {
+                return "utils";
+              }
+              return file.replace(/^src\//, "").replace(/index\.(ts|tsx)$/, "");
+            })(),
+            // 절대 경로
+            resolve(__dirname, file),
+          ],
+          ["src/**/*.{d,spec,stories}.{ts,tsx}"],
+        ),
+      ),
       formats: ["es", "cjs"],
       fileName,
     },

--- a/packages/react-utils/package.json
+++ b/packages/react-utils/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
+    "@repo/helpers": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@repo/vitest-config": "workspace:*",
     "@testing-library/dom": "^10.4.0",

--- a/packages/react-utils/vite.config.ts
+++ b/packages/react-utils/vite.config.ts
@@ -5,6 +5,7 @@ import react from "@vitejs/plugin-react";
 import dtsPlugin from "vite-plugin-dts";
 import tsConfigPaths from "vite-tsconfig-paths";
 import { preserveDirective } from "rollup-preserve-directives";
+import { runWithGlob } from "@repo/helpers/runWithGlob";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -18,11 +19,18 @@ export default defineConfig({
     emptyOutDir: false,
     lib: {
       name: "react-utils",
-      entry: {
-        hooks: resolve(__dirname, "src/hooks/index.ts"),
-        hocs: resolve(__dirname, "src/hocs/index.ts"),
-        providers: resolve(__dirname, "src/providers/index.ts"),
-      },
+      entry: Object.fromEntries(
+        runWithGlob(
+          "src/**/*.{ts,tsx}",
+          (file) => [
+            // 엔트리 이름
+            file.replace(/^src\//, "").replace(/index\.(ts|tsx)$/, ""),
+            // 절대 경로
+            resolve(__dirname, file),
+          ],
+          ["src/**/*.{d,spec}.{ts,tsx}"],
+        ),
+      ),
       formats: ["es", "cjs"],
       fileName: (format, entryName) => `${entryName}/index.${format}.js`,
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,6 +434,9 @@ importers:
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint-config
+      '@repo/helpers':
+        specifier: workspace:*
+        version: link:../../shared/helpers
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../configs/typescript-config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,6 +611,9 @@ importers:
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint-config
+      '@repo/helpers':
+        specifier: workspace:*
+        version: link:../../shared/helpers
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../configs/typescript-config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,6 +532,9 @@ importers:
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint-config
+      '@repo/helpers':
+        specifier: workspace:*
+        version: link:../../shared/helpers
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../configs/typescript-config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,6 +706,24 @@ importers:
         specifier: 5.8.2
         version: 5.8.2
 
+  shared/helpers:
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../../configs/typescript-config
+      '@types/node':
+        specifier: ^22.13.10
+        version: 22.13.10
+      eslint:
+        specifier: ^9.23.0
+        version: 9.23.0(jiti@2.4.2)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+
   tools/cli:
     dependencies:
       cli-spinners:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,6 +462,9 @@ importers:
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint-config
+      '@repo/helpers':
+        specifier: workspace:*
+        version: link:../../shared/helpers
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../configs/typescript-config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,9 @@ importers:
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint-config
+      '@repo/helpers':
+        specifier: workspace:*
+        version: link:../../shared/helpers
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../configs/typescript-config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -707,6 +707,10 @@ importers:
         version: 5.8.2
 
   shared/helpers:
+    dependencies:
+      glob:
+        specifier: ^11.0.1
+        version: 11.0.1
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - "packages/*"
   - "tools/*"
   - "configs/*"
+  - "shared/*"

--- a/shared/helpers/eslint.config.mjs
+++ b/shared/helpers/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { config } from "@repo/eslint-config/base";
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/shared/helpers/package.json
+++ b/shared/helpers/package.json
@@ -5,7 +5,9 @@
   "exports": {
     "./*": "./src/*.tsx"
   },
-  "scripts": {},
+  "scripts": {
+    "lint": "eslint . --max-warnings 0"
+  },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",

--- a/shared/helpers/package.json
+++ b/shared/helpers/package.json
@@ -6,7 +6,8 @@
     "./*": "./src/*.tsx"
   },
   "scripts": {
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint . --max-warnings 0",
+    "check-types": "tsc --noEmit"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/shared/helpers/package.json
+++ b/shared/helpers/package.json
@@ -3,11 +3,16 @@
   "version": "0.0.0",
   "private": true,
   "exports": {
-    "./*": "./src/*.tsx"
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js"
+    }
   },
   "scripts": {
     "lint": "eslint . --max-warnings 0",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "dev": "tsc --watch",
+    "build": "tsc"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/shared/helpers/package.json
+++ b/shared/helpers/package.json
@@ -16,6 +16,9 @@
     "eslint": "^9.23.0",
     "typescript": "5.8.2"
   },
+  "dependencies": {
+    "glob": "^11.0.1"
+  },
   "engines": {
     "node": ">=22"
   }

--- a/shared/helpers/package.json
+++ b/shared/helpers/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@repo/helpers",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    "./*": "./src/*.tsx"
+  },
+  "scripts": {},
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/node": "^22.13.10",
+    "eslint": "^9.23.0",
+    "typescript": "5.8.2"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/shared/helpers/src/runWithGlob.ts
+++ b/shared/helpers/src/runWithGlob.ts
@@ -1,0 +1,23 @@
+import { globSync } from "glob";
+
+/**
+ * run a job with a glob pattern
+ *
+ * @param pattern - glob pattern
+ * @param job - job to run for each file
+ * @param ignore - ignore pattern
+ * @returns promise of array of results
+ */
+export function runWithGlob<R>(
+  pattern: Parameters<typeof globSync>[0],
+  job: (file: string) => R,
+  ignore: Parameters<typeof globSync>[1]["ignore"],
+) {
+  // get the files from the glob pattern
+  const filesFromGlob = globSync(pattern, {
+    ignore: ignore,
+  });
+
+  // run the job for each file and return the results
+  return filesFromGlob.map(job);
+}

--- a/shared/helpers/src/runWithGlob.ts
+++ b/shared/helpers/src/runWithGlob.ts
@@ -16,7 +16,7 @@ export function runWithGlob<R>(
   // get the files from the glob pattern
   const filesFromGlob = globSync(pattern, {
     ignore: ignore,
-  });
+  }).sort();
 
   // run the job for each file and return the results
   return filesFromGlob.map(job);

--- a/shared/helpers/tsconfig.json
+++ b/shared/helpers/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
This pull request introduces several updates to streamline build processes, enhance dependency management, and improve library configuration. The key changes include updates to GitHub Actions workflows for caching shared resources, the addition of a new shared helper package, and the adoption of a dynamic entry-point generation approach in multiple packages.

### Workflow Enhancements
* Updated `.github/workflows/install-and-build.yml`, `.github/workflows/release.yml`, and `.github/workflows/unit-test.yml` to include caching for `shared/*` directories (`.turbo`, `node_modules`, and `dist`) to improve build efficiency. [[1]](diffhunk://#diff-63edbabb466f64fb74117cf964e6726dde43fef372be9d8bdbcd17b9f79875ceR24) [[2]](diffhunk://#diff-63edbabb466f64fb74117cf964e6726dde43fef372be9d8bdbcd17b9f79875ceR43) [[3]](diffhunk://#diff-63edbabb466f64fb74117cf964e6726dde43fef372be9d8bdbcd17b9f79875ceR66) [[4]](diffhunk://#diff-63edbabb466f64fb74117cf964e6726dde43fef372be9d8bdbcd17b9f79875ceR82) [[5]](diffhunk://#diff-63edbabb466f64fb74117cf964e6726dde43fef372be9d8bdbcd17b9f79875ceR94) [[6]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R36) [[7]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R48) [[8]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R60) [[9]](diffhunk://#diff-d4223b44df678cece85f2542c19b9cd060d43b22f753c25214d5942ef2ca5d18R110) [[10]](diffhunk://#diff-d4223b44df678cece85f2542c19b9cd060d43b22f753c25214d5942ef2ca5d18R126) [[11]](diffhunk://#diff-d4223b44df678cece85f2542c19b9cd060d43b22f753c25214d5942ef2ca5d18R137)

### Shared Helpers Integration
* Added a new `@repo/helpers` package in `pnpm-lock.yaml` and integrated it as a dependency across multiple packages (`browser-utils`, `http-clients`, `node-utils`, `react-ui`, `react-utils`). This package provides utility functions like `runWithGlob` for dynamic entry-point generation. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR724-R745) [[2]](diffhunk://#diff-b5eec4c2cafe589b7eaf36ef41ed4c7037b85636335c4f9fb9d4624d17e03b8dR38) [[3]](diffhunk://#diff-c3178d08bc13a5caab850d0f6cd501a87c991e543752dbe8c6755ce66d2e31afR35) [[4]](diffhunk://#diff-218d6f82fdd8813a3f0ca557b4711d8acea3d7e84153caf400481c30b6a4c3a8R43) [[5]](diffhunk://#diff-88d77dddb27a160ba5cc1bc8ca24012f8613052459094a94144062113d3b71a2R54) [[6]](diffhunk://#diff-ed47017c8d57a856394788fe12c953dcb28e67f5c9e4b7dd88c58de605bed48cR45)

### Dynamic Entry-Point Generation
* Replaced hardcoded entry points in `vite.config.ts` files for `browser-utils`, `http-clients`, `node-utils`, `react-ui`, and `react-utils` with a dynamic entry-point generation approach using the `runWithGlob` function from `@repo/helpers`. This simplifies configuration and ensures scalability. [[1]](diffhunk://#diff-f0adfff0d9b0d460414698fa9afc4e51bea20e48462d457e0971bdfac4fa41eaL14-R26) F91bedd4L11R12, [[2]](diffhunk://#diff-69970cefb9f68882807914090b10a6f2eaee24c27e869f9c604572b1815a5e5aL14-R26) [[3]](diffhunk://#diff-dfbb5d5ec1e5080d16287cdcd9f7e7034558fa092ca661ce988baf58d6ee0d79L46-R82) [[4]](diffhunk://#diff-91bb717c937d0a819c104c865fbf9874dd4e89b95b6577a9baa68bf98a2f5b62L21-R33)

### Package-Specific Improvements
* Added `"sideEffects": ["**/*.css"]` to `react-ui/package.json` to ensure proper handling of CSS files during tree-shaking.
* Introduced predefined mappings in `react-ui/vite.config.ts` for specific entry points to maintain compatibility with existing naming conventions.

### Dependency Management
* Updated `pnpm-lock.yaml` to reflect the addition of `@repo/helpers` and its dependencies, including `glob`. This ensures all packages have consistent access to shared utilities. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR724-R745) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR351-R353) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR437-R439) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR471-R473) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR535-R537) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR617-R619)

closes #114 