### PR TITLE
`install-and-build` 워크플로우에서 `.turbo` 디렉토리가 캐싱되지 않는 문제 수정

### DIFF
--- a/.github/workflows/install-and-build.yml
+++ b/.github/workflows/install-and-build.yml
@@ -15,6 +15,8 @@ jobs:
         id: cache-turbo
         uses: actions/cache@v4
         with:
+          # Consolidating multiple turbo cache paths into a single '.turbo' entry simplifies cache management
+          # and aligns with turbo's caching mechanism.
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: |

--- a/.github/workflows/install-and-build.yml
+++ b/.github/workflows/install-and-build.yml
@@ -15,13 +15,7 @@ jobs:
         id: cache-turbo
         uses: actions/cache@v4
         with:
-          path: |
-            .turbo
-            apps/*/.turbo
-            tools/*/.turbo
-            packages/*/.turbo
-            configs/*/.turbo
-            shared/*/.turbo
+          path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-
@@ -57,13 +51,7 @@ jobs:
       - name: Restore turbo cache
         uses: actions/cache@v4
         with:
-          path: |
-            .turbo
-            apps/*/.turbo
-            tools/*/.turbo
-            packages/*/.turbo
-            configs/*/.turbo
-            shared/*/.turbo
+          path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
       - name: Use Node.js 22.x
         uses: actions/setup-node@v4


### PR DESCRIPTION
This pull request simplifies the cache configuration for Turbo in the GitHub Actions workflow by consolidating multiple cache paths into a single entry. This change streamlines cache management and aligns better with Turbo's caching mechanism.

Changes to `.github/workflows/install-and-build.yml`:

* Consolidated multiple Turbo cache paths (`apps/*/.turbo`, `tools/*/.turbo`, etc.) into a single `.turbo` entry for both caching and restoring steps. This simplifies the workflow and improves alignment with Turbo's caching mechanism. [[1]](diffhunk://#diff-63edbabb466f64fb74117cf964e6726dde43fef372be9d8bdbcd17b9f79875ceL18-R20) [[2]](diffhunk://#diff-63edbabb466f64fb74117cf964e6726dde43fef372be9d8bdbcd17b9f79875ceL60-R56)

closes #57 