### PR TITLE
docker-compose 를 이용하는 워크플로우에서 이미지 빌드 시 GitHub Container Registry 로 레이어 캐싱을 지원하도록 개선

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -28,11 +28,6 @@ jobs:
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
 
-      - name: Pull cached images
-        run: |
-          docker pull ghcr.io/${{ github.repository_owner }}/web:cache || echo "No cached image found for web"
-          docker pull ghcr.io/${{ github.repository_owner }}/playwright-web:cache || echo "No cached image found for playwright-web"
-
       - name: inject environment variables
         run: |
           docker compose -f docker-compose.e2e.yaml convert > docker-compose.e2e.converted.yaml
@@ -43,11 +38,6 @@ jobs:
         id: build
         run: |
           docker compose -f docker-compose.e2e.converted.yaml build
-
-      - name: Push cached images
-        run: |
-          docker push ghcr.io/${{ github.repository_owner }}/web:cache
-          docker push ghcr.io/${{ github.repository_owner }}/playwright-web:cache
 
       - name: Prepare docker external network
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '*'
 
+env:
+  DOCKER_BUILDKIT: 1
+
 jobs:
   run-docker-compose-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/docker-cache
-          key: ${{ runner.os }}-e2e-${{ github.ref_name }}
+          key: ${{ runner.os }}-e2e-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-e2e-
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -28,31 +28,24 @@ jobs:
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
 
-      - name: Setup Docker image Caching
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker-cache
-          key: ${{ runner.os }}-e2e-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-e2e-
-
-      - name: Load Docker image from tar
+      - name: Pull cached images
         run: |
-          if [ -f /tmp/docker-cache/playwright-web.tar ]; then
-            docker load -i /tmp/docker-cache/playwright-web.tar
-          else
-            echo "No cached image found for playwright-web"
-          fi
-          if [ -f /tmp/docker-cache/web.tar ]; then
-            docker load -i /tmp/docker-cache/web.tar
-          else
-            echo "No cached image found for web"
-          fi
+          docker pull ghcr.io/${{ github.repository_owner }}/web:cache || echo "No cached image found for web"
+          docker pull ghcr.io/${{ github.repository_owner }}/playwright-web:cache || echo "No cached image found for playwright-web"
 
       - name: Build E2E environment
         id: build
         run: |
-          docker compose -f docker-compose.e2e.yaml build
+          docker compose -f docker-compose.e2e.yaml build \
+            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:cache \
+            --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:cache,mode=max \
+            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/playwright-web:cache \
+            --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/playwright-web:cache,mode=max
+
+      - name: Push cached images
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/web:cache
+          docker push ghcr.io/${{ github.repository_owner }}/playwright-web:cache
 
       - name: Prepare docker external network
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -33,14 +33,16 @@ jobs:
           docker pull ghcr.io/${{ github.repository_owner }}/web:cache || echo "No cached image found for web"
           docker pull ghcr.io/${{ github.repository_owner }}/playwright-web:cache || echo "No cached image found for playwright-web"
 
+      - name: inject environment variables
+        run: |
+          docker compose -f docker-compose.e2e.yaml convert > docker-compose.e2e.converted.yaml
+        env:
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+
       - name: Build E2E environment
         id: build
         run: |
-          docker compose -f docker-compose.e2e.yaml build \
-            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:cache \
-            --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:cache,mode=max \
-            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/playwright-web:cache \
-            --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/playwright-web:cache,mode=max
+          docker compose -f docker-compose.e2e.converted.yaml build
 
       - name: Push cached images
         run: |
@@ -53,7 +55,7 @@ jobs:
 
       - name: Run E2E tests
         run: |
-          docker compose -f docker-compose.e2e.yaml up --exit-code-from playwright-web
+          docker compose -f docker-compose.e2e.converted.yaml up --exit-code-from playwright-web
 
       - name: Copy E2E report from container
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -18,6 +18,13 @@ jobs:
       - name: Ensure Docker cache directory exists
         run: mkdir -p /tmp/docker-cache
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,35 +12,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Ensure Docker cache directory exists
-        run: mkdir -p /tmp/docker-cache
-
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
-
-      - name: Setup Docker image Caching
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker-cache
-          key: ${{ runner.os }}-e2e-${{ github.ref_name }}
-          restore-keys: |
-            ${{ runner.os }}-e2e-
-
-      - name: Load Docker image from tar
-        run: |
-          if [ -f /tmp/docker-cache/playwright-web.tar ]; then
-            docker load -i /tmp/docker-cache/playwright-web.tar
-          fi
-          if [ -f /tmp/docker-cache/web.tar ]; then
-            docker load -i /tmp/docker-cache/web.tar
-          fi
 
       - name: Build E2E environment
         id: build
         run: |
           docker compose -f docker-compose.e2e.yaml build
-          docker save -o /tmp/docker-cache/playwright-web.tar turborepo-template-playwright-web:latest
-          docker save -o /tmp/docker-cache/web.tar turborepo-template-web:latest
 
       - name: Prepare docker external network
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: inject environment variables
         run: |
-          docker compose -f docker-compose.e2e.yaml convert > docker-compose.e2e.converted.yaml
+          docker compose -f docker-compose.ci.e2e.yaml convert > docker-compose.e2e.converted.yaml
         env:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,13 +12,35 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Ensure Docker cache directory exists
+        run: mkdir -p /tmp/docker-cache
+
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
+
+      - name: Setup Docker image Caching
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker-cache
+          key: ${{ runner.os }}-e2e-${{ github.ref_name }}
+          restore-keys: |
+            ${{ runner.os }}-e2e-
+
+      - name: Load Docker image from tar
+        run: |
+          if [ -f /tmp/docker-cache/playwright-web.tar ]; then
+            docker load -i /tmp/docker-cache/playwright-web.tar
+          fi
+          if [ -f /tmp/docker-cache/web.tar ]; then
+            docker load -i /tmp/docker-cache/web.tar
+          fi
 
       - name: Build E2E environment
         id: build
         run: |
           docker compose -f docker-compose.e2e.yaml build
+          docker save -o /tmp/docker-cache/playwright-web.tar turborepo-template-playwright-web:latest
+          docker save -o /tmp/docker-cache/web.tar turborepo-template-web:latest
 
       - name: Prepare docker external network
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -30,9 +30,13 @@ jobs:
         run: |
           if [ -f /tmp/docker-cache/playwright-web.tar ]; then
             docker load -i /tmp/docker-cache/playwright-web.tar
+          else
+            echo "No cached image found for playwright-web"
           fi
           if [ -f /tmp/docker-cache/web.tar ]; then
             docker load -i /tmp/docker-cache/web.tar
+          else
+            echo "No cached image found for web"
           fi
 
       - name: Build E2E environment

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -43,8 +43,6 @@ jobs:
         id: build
         run: |
           docker compose -f docker-compose.e2e.yaml build
-          docker save -o /tmp/docker-cache/playwright-web.tar turborepo-template-playwright-web:latest
-          docker save -o /tmp/docker-cache/web.tar turborepo-template-web:latest
 
       - name: Prepare docker external network
         run: |

--- a/.github/workflows/lighthouse-test.yml
+++ b/.github/workflows/lighthouse-test.yml
@@ -28,26 +28,10 @@ jobs:
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
 
-      - name: Setup Docker image Caching
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker-cache
-          key: ${{ runner.os }}-lighthouse-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-lighthouse-
-
-      - name: Load Docker image from tar
+      - name: Pull cached images
         run: |
-          if [ -f /tmp/docker-cache/lighthouse-runner.tar ]; then
-            docker load -i /tmp/docker-cache/lighthouse-runner.tar
-          else
-            echo "No cached image found for lighthouse-runner"
-          fi
-          if [ -f /tmp/docker-cache/web.tar ]; then
-            docker load -i /tmp/docker-cache/web.tar
-          else
-            echo "No cached image found for web"
-          fi
+          docker pull ghcr.io/${{ github.repository_owner }}/web:cache || echo "No cached image found for web"
+          docker pull ghcr.io/${{ github.repository_owner }}/lighthouse-runner:cache || echo "No cached image found for lighthouse-runner"
 
       - name: inject LHCI_GITHUB_APP_TOKEN
         run: |
@@ -58,7 +42,16 @@ jobs:
       - name: Build Lighthouse environment
         id: build
         run: |
-          docker compose -f docker-compose.lighthouse.converted.yaml build
+          docker compose -f docker-compose.lighthouse.converted.yaml build \
+            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:cache \
+            --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:cache,mode=max \
+            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/lighthouse-runner:cache \
+            --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/lighthouse-runner:cache,mode=max
+
+      - name: Push cached images
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/web:cache
+          docker push ghcr.io/${{ github.repository_owner }}/lighthouse-runner:cache
 
       - name: Prepare docker external network
         run: |

--- a/.github/workflows/lighthouse-test.yml
+++ b/.github/workflows/lighthouse-test.yml
@@ -49,8 +49,6 @@ jobs:
         id: build
         run: |
           docker compose -f docker-compose.lighthouse.converted.yaml build
-          docker save -o /tmp/docker-cache/lighthouse-runner.tar turborepo-template-lighthouse-runner:latest
-          docker save -o /tmp/docker-cache/web.tar turborepo-template-web:latest
 
       - name: Prepare docker external network
         run: |

--- a/.github/workflows/lighthouse-test.yml
+++ b/.github/workflows/lighthouse-test.yml
@@ -33,20 +33,17 @@ jobs:
           docker pull ghcr.io/${{ github.repository_owner }}/web:cache || echo "No cached image found for web"
           docker pull ghcr.io/${{ github.repository_owner }}/lighthouse-runner:cache || echo "No cached image found for lighthouse-runner"
 
-      - name: inject LHCI_GITHUB_APP_TOKEN
+      - name: inject environment variables
         run: |
           docker compose -f docker-compose.lighthouse.yaml convert > docker-compose.lighthouse.converted.yaml
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
 
       - name: Build Lighthouse environment
         id: build
         run: |
-          docker compose -f docker-compose.lighthouse.converted.yaml build \
-            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:cache \
-            --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:cache,mode=max \
-            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/lighthouse-runner:cache \
-            --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/lighthouse-runner:cache,mode=max
+          docker compose -f docker-compose.lighthouse.converted.yaml build
 
       - name: Push cached images
         run: |

--- a/.github/workflows/lighthouse-test.yml
+++ b/.github/workflows/lighthouse-test.yml
@@ -12,8 +12,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Ensure Docker cache directory exists
+        run: mkdir -p /tmp/docker-cache
+
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
+
+      - name: Setup Docker image Caching
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker-cache
+          key: ${{ runner.os }}-lighthouse-${{ github.ref_name }}
+          restore-keys: |
+            ${{ runner.os }}-lighthouse-
+
+      - name: Load Docker image from tar
+        run: |
+          if [ -f /tmp/docker-cache/lighthouse-runner.tar ]; then
+            docker load -i /tmp/docker-cache/lighthouse-runner.tar
+          fi
+          if [ -f /tmp/docker-cache/web.tar ]; then
+            docker load -i /tmp/docker-cache/web.tar
+          fi
 
       - name: inject LHCI_GITHUB_APP_TOKEN
         run: |
@@ -25,6 +45,8 @@ jobs:
         id: build
         run: |
           docker compose -f docker-compose.lighthouse.converted.yaml build
+          docker save -o /tmp/docker-cache/lighthouse-runner.tar turborepo-template-lighthouse-runner:latest
+          docker save -o /tmp/docker-cache/web.tar turborepo-template-web:latest
 
       - name: Prepare docker external network
         run: |

--- a/.github/workflows/lighthouse-test.yml
+++ b/.github/workflows/lighthouse-test.yml
@@ -28,11 +28,6 @@ jobs:
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
 
-      - name: Pull cached images
-        run: |
-          docker pull ghcr.io/${{ github.repository_owner }}/web:cache || echo "No cached image found for web"
-          docker pull ghcr.io/${{ github.repository_owner }}/lighthouse-runner:cache || echo "No cached image found for lighthouse-runner"
-
       - name: inject environment variables
         run: |
           docker compose -f docker-compose.lighthouse.yaml convert > docker-compose.lighthouse.converted.yaml
@@ -44,11 +39,6 @@ jobs:
         id: build
         run: |
           docker compose -f docker-compose.lighthouse.converted.yaml build
-
-      - name: Push cached images
-        run: |
-          docker push ghcr.io/${{ github.repository_owner }}/web:cache
-          docker push ghcr.io/${{ github.repository_owner }}/lighthouse-runner:cache
 
       - name: Prepare docker external network
         run: |

--- a/.github/workflows/lighthouse-test.yml
+++ b/.github/workflows/lighthouse-test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/docker-cache
-          key: ${{ runner.os }}-lighthouse-${{ github.ref_name }}
+          key: ${{ runner.os }}-lighthouse-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-lighthouse-
 

--- a/.github/workflows/lighthouse-test.yml
+++ b/.github/workflows/lighthouse-test.yml
@@ -12,28 +12,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Ensure Docker cache directory exists
-        run: mkdir -p /tmp/docker-cache
-
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
-
-      - name: Setup Docker image Caching
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker-cache
-          key: ${{ runner.os }}-lighthouse-${{ github.ref_name }}
-          restore-keys: |
-            ${{ runner.os }}-lighthouse-
-
-      - name: Load Docker image from tar
-        run: |
-          if [ -f /tmp/docker-cache/lighthouse-runner.tar ]; then
-            docker load -i /tmp/docker-cache/lighthouse-runner.tar
-          fi
-          if [ -f /tmp/docker-cache/web.tar ]; then
-            docker load -i /tmp/docker-cache/web.tar
-          fi
 
       - name: inject LHCI_GITHUB_APP_TOKEN
         run: |
@@ -45,8 +25,6 @@ jobs:
         id: build
         run: |
           docker compose -f docker-compose.lighthouse.converted.yaml build
-          docker save -o /tmp/docker-cache/lighthouse-runner.tar turborepo-template-lighthouse-runner:latest
-          docker save -o /tmp/docker-cache/web.tar turborepo-template-web:latest
 
       - name: Prepare docker external network
         run: |

--- a/.github/workflows/lighthouse-test.yml
+++ b/.github/workflows/lighthouse-test.yml
@@ -18,6 +18,13 @@ jobs:
       - name: Ensure Docker cache directory exists
         run: mkdir -p /tmp/docker-cache
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/lighthouse-test.yml
+++ b/.github/workflows/lighthouse-test.yml
@@ -30,9 +30,13 @@ jobs:
         run: |
           if [ -f /tmp/docker-cache/lighthouse-runner.tar ]; then
             docker load -i /tmp/docker-cache/lighthouse-runner.tar
+          else
+            echo "No cached image found for lighthouse-runner"
           fi
           if [ -f /tmp/docker-cache/web.tar ]; then
             docker load -i /tmp/docker-cache/web.tar
+          else
+            echo "No cached image found for web"
           fi
 
       - name: inject LHCI_GITHUB_APP_TOKEN

--- a/.github/workflows/lighthouse-test.yml
+++ b/.github/workflows/lighthouse-test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: inject environment variables
         run: |
-          docker compose -f docker-compose.lighthouse.yaml convert > docker-compose.lighthouse.converted.yaml
+          docker compose -f docker-compose.ci.lighthouse.yaml convert > docker-compose.lighthouse.converted.yaml
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/lighthouse-test.yml
+++ b/.github/workflows/lighthouse-test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '*'
 
+env:
+  DOCKER_BUILDKIT: 1
+
 jobs:
   run-docker-compose-lighthouse:
     runs-on: ubuntu-latest

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -33,14 +33,17 @@ jobs:
           docker pull ghcr.io/${{ github.repository_owner }}/storybook:cache || echo "No cached image found for storybook"
           docker pull ghcr.io/${{ github.repository_owner }}/storybook-test-runner:cache || echo "No cached image found for storybook-test-runner"
 
+
+      - name: inject environment variables
+        run: |
+          docker compose -f docker-compose.storybook.yaml convert > docker-compose.storybook.converted.yaml
+        env:
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+
       - name: Build Storybook test environment
         id: build
         run: |
-          docker compose -f docker-compose.storybook.yaml build \
-            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/storybook:cache \
-            --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/storybook:cache,mode=max \
-            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/storybook-test-runner:cache \
-            --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/storybook-test-runner:cache,mode=max
+          docker compose -f docker-compose.storybook.converted.yaml build
 
       - name: Push cached images
         run: |
@@ -53,7 +56,7 @@ jobs:
 
       - name: Run Storybook tests
         run: |
-          docker compose -f docker-compose.storybook.yaml up --exit-code-from storybook-test-runner
+          docker compose -f docker-compose.storybook.converted.yaml up --exit-code-from storybook-test-runner
 
       - name: Copy Storybook report from container
         run: |

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: inject environment variables
         run: |
-          docker compose -f docker-compose.storybook.yaml convert > docker-compose.storybook.converted.yaml
+          docker compose -f docker-compose.ci.storybook.yaml convert > docker-compose.storybook.converted.yaml
         env:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
 

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -43,8 +43,6 @@ jobs:
         id: build
         run: |
           docker compose -f docker-compose.storybook.yaml build
-          docker save -o /tmp/docker-cache/storybook-test-runner.tar turborepo-template-storybook-test-runner:latest
-          docker save -o /tmp/docker-cache/storybook.tar turborepo-template-storybook:latest
 
       - name: Prepare docker external network
         run: |

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/docker-cache
-          key: ${{ runner.os }}-storybook-${{ github.ref_name }}
+          key: ${{ runner.os }}-storybook-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-storybook-
 

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -18,6 +18,13 @@ jobs:
       - name: Ensure Docker cache directory exists
         run: mkdir -p /tmp/docker-cache
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -28,12 +28,6 @@ jobs:
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
 
-      - name: Pull cached images
-        run: |
-          docker pull ghcr.io/${{ github.repository_owner }}/storybook:cache || echo "No cached image found for storybook"
-          docker pull ghcr.io/${{ github.repository_owner }}/storybook-test-runner:cache || echo "No cached image found for storybook-test-runner"
-
-
       - name: inject environment variables
         run: |
           docker compose -f docker-compose.storybook.yaml convert > docker-compose.storybook.converted.yaml
@@ -44,11 +38,6 @@ jobs:
         id: build
         run: |
           docker compose -f docker-compose.storybook.converted.yaml build
-
-      - name: Push cached images
-        run: |
-          docker push ghcr.io/${{ github.repository_owner }}/storybook:cache
-          docker push ghcr.io/${{ github.repository_owner }}/storybook-test-runner:cache
 
       - name: Prepare docker external network
         run: |

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '*'
 
+env:
+  DOCKER_BUILDKIT: 1
+
 jobs:
   run-docker-compose-storybook:
     runs-on: ubuntu-latest

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -12,13 +12,35 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Ensure Docker cache directory exists
+        run: mkdir -p /tmp/docker-cache
+
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
+
+      - name: Setup Docker image Caching
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker-cache
+          key: ${{ runner.os }}-storybook-${{ github.ref_name }}
+          restore-keys: |
+            ${{ runner.os }}-storybook-
+
+      - name: Load Docker image from tar
+        run: |
+          if [ -f /tmp/docker-cache/storybook-test-runner.tar ]; then
+            docker load -i /tmp/docker-cache/storybook-test-runner.tar
+          fi
+          if [ -f /tmp/docker-cache/storybook.tar ]; then
+            docker load -i /tmp/docker-cache/storybook.tar
+          fi
 
       - name: Build Storybook test environment
         id: build
         run: |
           docker compose -f docker-compose.storybook.yaml build
+          docker save -o /tmp/docker-cache/storybook-test-runner.tar turborepo-template-storybook-test-runner:latest
+          docker save -o /tmp/docker-cache/storybook.tar turborepo-template-storybook:latest
 
       - name: Prepare docker external network
         run: |

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -12,35 +12,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Ensure Docker cache directory exists
-        run: mkdir -p /tmp/docker-cache
-
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
-
-      - name: Setup Docker image Caching
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker-cache
-          key: ${{ runner.os }}-storybook-${{ github.ref_name }}
-          restore-keys: |
-            ${{ runner.os }}-storybook-
-
-      - name: Load Docker image from tar
-        run: |
-          if [ -f /tmp/docker-cache/storybook-test-runner.tar ]; then
-            docker load -i /tmp/docker-cache/storybook-test-runner.tar
-          fi
-          if [ -f /tmp/docker-cache/storybook.tar ]; then
-            docker load -i /tmp/docker-cache/storybook.tar
-          fi
 
       - name: Build Storybook test environment
         id: build
         run: |
           docker compose -f docker-compose.storybook.yaml build
-          docker save -o /tmp/docker-cache/storybook-test-runner.tar turborepo-template-storybook-test-runner:latest
-          docker save -o /tmp/docker-cache/storybook.tar turborepo-template-storybook:latest
 
       - name: Prepare docker external network
         run: |

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -30,9 +30,13 @@ jobs:
         run: |
           if [ -f /tmp/docker-cache/storybook-test-runner.tar ]; then
             docker load -i /tmp/docker-cache/storybook-test-runner.tar
+          else
+            echo "No cached image found for storybook-test-runner"
           fi
           if [ -f /tmp/docker-cache/storybook.tar ]; then
             docker load -i /tmp/docker-cache/storybook.tar
+          else
+            echo "No cached image found for storybook"
           fi
 
       - name: Build Storybook test environment

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -28,31 +28,24 @@ jobs:
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
 
-      - name: Setup Docker image Caching
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker-cache
-          key: ${{ runner.os }}-storybook-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-storybook-
-
-      - name: Load Docker image from tar
+      - name: Pull cached images
         run: |
-          if [ -f /tmp/docker-cache/storybook-test-runner.tar ]; then
-            docker load -i /tmp/docker-cache/storybook-test-runner.tar
-          else
-            echo "No cached image found for storybook-test-runner"
-          fi
-          if [ -f /tmp/docker-cache/storybook.tar ]; then
-            docker load -i /tmp/docker-cache/storybook.tar
-          else
-            echo "No cached image found for storybook"
-          fi
+          docker pull ghcr.io/${{ github.repository_owner }}/storybook:cache || echo "No cached image found for storybook"
+          docker pull ghcr.io/${{ github.repository_owner }}/storybook-test-runner:cache || echo "No cached image found for storybook-test-runner"
 
       - name: Build Storybook test environment
         id: build
         run: |
-          docker compose -f docker-compose.storybook.yaml build
+          docker compose -f docker-compose.storybook.yaml build \
+            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/storybook:cache \
+            --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/storybook:cache,mode=max \
+            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/storybook-test-runner:cache \
+            --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/storybook-test-runner:cache,mode=max
+
+      - name: Push cached images
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/storybook:cache
+          docker push ghcr.io/${{ github.repository_owner }}/storybook-test-runner:cache
 
       - name: Prepare docker external network
         run: |

--- a/docker-compose.ci.e2e.yaml
+++ b/docker-compose.ci.e2e.yaml
@@ -7,6 +7,10 @@ services:
     build:
       context: .
       dockerfile: ./apps/web/Dockerfile
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/web:cache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/web:cache,mode=max
     ports:
       - 3000:3000
     networks:
@@ -17,6 +21,10 @@ services:
     build:
       context: .
       dockerfile: ./tools/playwright-web/Dockerfile
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/playwright-web:cache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/playwright-web:cache,mode=max
     networks:
       - e2e_network
     depends_on:

--- a/docker-compose.ci.lighthouse.yaml
+++ b/docker-compose.ci.lighthouse.yaml
@@ -7,6 +7,10 @@ services:
     build:
       context: .
       dockerfile: ./apps/web/Dockerfile
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/web:cache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/web:cache,mode=max
     ports:
       - 3000:3000
     networks:
@@ -17,6 +21,10 @@ services:
     build:
       context: .
       dockerfile: ./tools/lighthouse-ci/Dockerfile
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/lighthouse-runner:cache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/lighthouse-runner:cache,mode=max
     networks:
       - lighthouse_network
     depends_on:

--- a/docker-compose.ci.storybook.yaml
+++ b/docker-compose.ci.storybook.yaml
@@ -7,6 +7,10 @@ services:
     build:
       context: .
       dockerfile: apps/frontend-workshop/Dockerfile
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/storybook:cache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/storybook:cache,mode=max
     ports:
       - 6006:80
     networks:
@@ -17,6 +21,10 @@ services:
     build:
       context: .
       dockerfile: apps/frontend-workshop/Dockerfile.test-runner
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/storybook-test-runner:cache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/storybook-test-runner:cache,mode=max
     networks:
       - storybook_network
     depends_on:

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -10,7 +10,7 @@ services:
       cache_from:
         - turborepo-template-web:latest
       cache_to:
-        - turborepo-template-web:latest
+        - type=local,dest=/tmp/docker-cache
     ports:
       - 3000:3000
     networks:
@@ -24,7 +24,7 @@ services:
       cache_from:
         - turborepo-template-playwright-web:latest
       cache_to:
-        - turborepo-template-playwright-web:latest
+        - type=local,dest=/tmp/docker-cache
     networks:
       - e2e_network
     depends_on:

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -7,10 +7,6 @@ services:
     build:
       context: .
       dockerfile: ./apps/web/Dockerfile
-      cache_from:
-        - type=gha
-      cache_to:
-        - type=gha
     ports:
       - 3000:3000
     networks:
@@ -21,10 +17,6 @@ services:
     build:
       context: .
       dockerfile: ./tools/playwright-web/Dockerfile
-      cache_from:
-        - type=gha
-      cache_to:
-        - type=gha
     networks:
       - e2e_network
     depends_on:

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -9,6 +9,8 @@ services:
       dockerfile: ./apps/web/Dockerfile
       cache_from:
         - turborepo-template-web:latest
+      cache_to:
+        - turborepo-template-web:latest
     ports:
       - 3000:3000
     networks:
@@ -20,6 +22,8 @@ services:
       context: .
       dockerfile: ./tools/playwright-web/Dockerfile
       cache_from:
+        - turborepo-template-playwright-web:latest
+      cache_to:
         - turborepo-template-playwright-web:latest
     networks:
       - e2e_network

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -8,9 +8,9 @@ services:
       context: .
       dockerfile: ./apps/web/Dockerfile
       cache_from:
-        - type=local,src=/tmp/docker-cache,ref=turborepo-template-web:latest
+        - type=gha
       cache_to:
-        - type=local,dest=/tmp/docker-cache
+        - type=gha
     ports:
       - 3000:3000
     networks:
@@ -22,9 +22,9 @@ services:
       context: .
       dockerfile: ./tools/playwright-web/Dockerfile
       cache_from:
-        - type=local,src=/tmp/docker-cache,ref=turborepo-template-playwright-web:latest
+        - type=gha
       cache_to:
-        - type=local,dest=/tmp/docker-cache
+        - type=gha
     networks:
       - e2e_network
     depends_on:

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -8,7 +8,7 @@ services:
       context: .
       dockerfile: ./apps/web/Dockerfile
       cache_from:
-        - turborepo-template-web:latest
+        - type=local,src=/tmp/docker-cache,ref=turborepo-template-web:latest
       cache_to:
         - type=local,dest=/tmp/docker-cache
     ports:
@@ -22,7 +22,7 @@ services:
       context: .
       dockerfile: ./tools/playwright-web/Dockerfile
       cache_from:
-        - turborepo-template-playwright-web:latest
+        - type=local,src=/tmp/docker-cache,ref=turborepo-template-playwright-web:latest
       cache_to:
         - type=local,dest=/tmp/docker-cache
     networks:

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -7,6 +7,10 @@ services:
     build:
       context: .
       dockerfile: ./apps/web/Dockerfile
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/web:cache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/web:cache,mode=max
     ports:
       - 3000:3000
     networks:
@@ -17,6 +21,10 @@ services:
     build:
       context: .
       dockerfile: ./tools/playwright-web/Dockerfile
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/playwright-web:cache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/playwright-web:cache,mode=max
     networks:
       - e2e_network
     depends_on:

--- a/docker-compose.lighthouse.yaml
+++ b/docker-compose.lighthouse.yaml
@@ -8,7 +8,7 @@ services:
       context: .
       dockerfile: ./apps/web/Dockerfile
       cache_from:
-        - turborepo-template-web:latest
+        - type=local,src=/tmp/docker-cache,ref=turborepo-template-web:latest
       cache_to:
         - type=local,dest=/tmp/docker-cache
     ports:
@@ -22,7 +22,7 @@ services:
       context: .
       dockerfile: ./tools/lighthouse-ci/Dockerfile
       cache_from:
-        - turborepo-template-lighthouse-runner:latest
+        - type=local,src=/tmp/docker-cache,ref=turborepo-template-lighthouse-runner:latest
       cache_to:
         - type=local,dest=/tmp/docker-cache
     networks:

--- a/docker-compose.lighthouse.yaml
+++ b/docker-compose.lighthouse.yaml
@@ -10,7 +10,7 @@ services:
       cache_from:
         - turborepo-template-web:latest
       cache_to:
-        - turborepo-template-web:latest
+        - type=local,dest=/tmp/docker-cache
     ports:
       - 3000:3000
     networks:
@@ -24,7 +24,7 @@ services:
       cache_from:
         - turborepo-template-lighthouse-runner:latest
       cache_to:
-        - turborepo-template-lighthouse-runner:latest
+        - type=local,dest=/tmp/docker-cache
     networks:
       - lighthouse_network
     depends_on:

--- a/docker-compose.lighthouse.yaml
+++ b/docker-compose.lighthouse.yaml
@@ -9,6 +9,8 @@ services:
       dockerfile: ./apps/web/Dockerfile
       cache_from:
         - turborepo-template-web:latest
+      cache_to:
+        - turborepo-template-web:latest
     ports:
       - 3000:3000
     networks:
@@ -20,6 +22,8 @@ services:
       context: .
       dockerfile: ./tools/lighthouse-ci/Dockerfile
       cache_from:
+        - turborepo-template-lighthouse-runner:latest
+      cache_to:
         - turborepo-template-lighthouse-runner:latest
     networks:
       - lighthouse_network

--- a/docker-compose.lighthouse.yaml
+++ b/docker-compose.lighthouse.yaml
@@ -7,6 +7,10 @@ services:
     build:
       context: .
       dockerfile: ./apps/web/Dockerfile
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/web:cache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/web:cache,mode=max
     ports:
       - 3000:3000
     networks:
@@ -17,6 +21,10 @@ services:
     build:
       context: .
       dockerfile: ./tools/lighthouse-ci/Dockerfile
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/lighthouse-runner:cache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/lighthouse-runner:cache,mode=max
     networks:
       - lighthouse_network
     depends_on:

--- a/docker-compose.lighthouse.yaml
+++ b/docker-compose.lighthouse.yaml
@@ -7,10 +7,6 @@ services:
     build:
       context: .
       dockerfile: ./apps/web/Dockerfile
-      cache_from:
-        - type=gha
-      cache_to:
-        - type=gha
     ports:
       - 3000:3000
     networks:
@@ -21,10 +17,6 @@ services:
     build:
       context: .
       dockerfile: ./tools/lighthouse-ci/Dockerfile
-      cache_from:
-        - type=gha
-      cache_to:
-        - type=gha
     networks:
       - lighthouse_network
     depends_on:

--- a/docker-compose.lighthouse.yaml
+++ b/docker-compose.lighthouse.yaml
@@ -8,9 +8,9 @@ services:
       context: .
       dockerfile: ./apps/web/Dockerfile
       cache_from:
-        - type=local,src=/tmp/docker-cache,ref=turborepo-template-web:latest
+        - type=gha
       cache_to:
-        - type=local,dest=/tmp/docker-cache
+        - type=gha
     ports:
       - 3000:3000
     networks:
@@ -22,9 +22,9 @@ services:
       context: .
       dockerfile: ./tools/lighthouse-ci/Dockerfile
       cache_from:
-        - type=local,src=/tmp/docker-cache,ref=turborepo-template-lighthouse-runner:latest
+        - type=gha
       cache_to:
-        - type=local,dest=/tmp/docker-cache
+        - type=gha
     networks:
       - lighthouse_network
     depends_on:

--- a/docker-compose.storybook.yaml
+++ b/docker-compose.storybook.yaml
@@ -8,9 +8,9 @@ services:
       context: .
       dockerfile: apps/frontend-workshop/Dockerfile
       cache_from:
-        - type=local,src=/tmp/docker-cache,ref=turborepo-template-frontend-workshop:latest
+        - type=gha
       cache_to:
-        - type=local,dest=/tmp/docker-cache
+        - type=gha
     ports:
       - 6006:80
     networks:
@@ -22,9 +22,9 @@ services:
       context: .
       dockerfile: apps/frontend-workshop/Dockerfile.test-runner
       cache_from:
-        - type=local,src=/tmp/docker-cache,ref=turborepo-template-frontend-workshop-test-runner:latest
+        - type=gha
       cache_to:
-        - type=local,dest=/tmp/docker-cache
+        - type=gha
     networks:
       - storybook_network
     depends_on:

--- a/docker-compose.storybook.yaml
+++ b/docker-compose.storybook.yaml
@@ -8,7 +8,7 @@ services:
       context: .
       dockerfile: apps/frontend-workshop/Dockerfile
       cache_from:
-        - turborepo-template-frontend-workshop:latest
+        - type=local,src=/tmp/docker-cache,ref=turborepo-template-frontend-workshop:latest
       cache_to:
         - type=local,dest=/tmp/docker-cache
     ports:
@@ -22,7 +22,7 @@ services:
       context: .
       dockerfile: apps/frontend-workshop/Dockerfile.test-runner
       cache_from:
-        - turborepo-template-frontend-workshop-test-runner:latest
+        - type=local,src=/tmp/docker-cache,ref=turborepo-template-frontend-workshop-test-runner:latest
       cache_to:
         - type=local,dest=/tmp/docker-cache
     networks:

--- a/docker-compose.storybook.yaml
+++ b/docker-compose.storybook.yaml
@@ -7,6 +7,10 @@ services:
     build:
       context: .
       dockerfile: apps/frontend-workshop/Dockerfile
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/storybook:cache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/storybook:cache,mode=max
     ports:
       - 6006:80
     networks:
@@ -17,6 +21,10 @@ services:
     build:
       context: .
       dockerfile: apps/frontend-workshop/Dockerfile.test-runner
+      cache_from:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/storybook-test-runner:cache
+      cache_to:
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/storybook-test-runner:cache,mode=max
     networks:
       - storybook_network
     depends_on:

--- a/docker-compose.storybook.yaml
+++ b/docker-compose.storybook.yaml
@@ -9,6 +9,8 @@ services:
       dockerfile: apps/frontend-workshop/Dockerfile
       cache_from:
         - turborepo-template-frontend-workshop:latest
+      cache_to:
+        - turborepo-template-frontend-workshop:latest
     ports:
       - 6006:80
     networks:
@@ -20,6 +22,8 @@ services:
       context: .
       dockerfile: apps/frontend-workshop/Dockerfile.test-runner
       cache_from:
+        - turborepo-template-frontend-workshop-test-runner:latest
+      cache_to:
         - turborepo-template-frontend-workshop-test-runner:latest
     networks:
       - storybook_network

--- a/docker-compose.storybook.yaml
+++ b/docker-compose.storybook.yaml
@@ -7,10 +7,6 @@ services:
     build:
       context: .
       dockerfile: apps/frontend-workshop/Dockerfile
-      cache_from:
-        - type=gha
-      cache_to:
-        - type=gha
     ports:
       - 6006:80
     networks:
@@ -21,10 +17,6 @@ services:
     build:
       context: .
       dockerfile: apps/frontend-workshop/Dockerfile.test-runner
-      cache_from:
-        - type=gha
-      cache_to:
-        - type=gha
     networks:
       - storybook_network
     depends_on:

--- a/docker-compose.storybook.yaml
+++ b/docker-compose.storybook.yaml
@@ -10,7 +10,7 @@ services:
       cache_from:
         - turborepo-template-frontend-workshop:latest
       cache_to:
-        - turborepo-template-frontend-workshop:latest
+        - type=local,dest=/tmp/docker-cache
     ports:
       - 6006:80
     networks:
@@ -24,7 +24,7 @@ services:
       cache_from:
         - turborepo-template-frontend-workshop-test-runner:latest
       cache_to:
-        - turborepo-template-frontend-workshop-test-runner:latest
+        - type=local,dest=/tmp/docker-cache
     networks:
       - storybook_network
     depends_on:


### PR DESCRIPTION
This pull request refactors the CI workflows for E2E, Lighthouse, and Storybook tests by improving Docker build processes, removing Docker image caching, and introducing new `docker-compose` configuration files. These changes aim to streamline the build process, enhance maintainability, and leverage GitHub Container Registry for caching.

### Workflow Improvements

* **Added `DOCKER_BUILDKIT` environment variable** in `.github/workflows/e2e-test.yml`, `.github/workflows/lighthouse-test.yml`, and `.github/workflows/storybook-test.yml` to enable Docker BuildKit for improved build performance. [[1]](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2R8-R10) [[2]](diffhunk://#diff-5792fdfb83a2b96c0766446871965cbf84e50b4bc3fe3ed8d3ea85f834cec7d3R8-R10) [[3]](diffhunk://#diff-44e0997692527cdd0cfd415cb4ca4a4c15f89b3ac8623ba58fece1d1ae1da5f9R8-R10)
* **Replaced Docker image caching with GitHub Container Registry**:
  - Removed the `actions/cache` step and added a `docker/login-action` step to authenticate with the GitHub Container Registry. [[1]](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2R21-R48) [[2]](diffhunk://#diff-5792fdfb83a2b96c0766446871965cbf84e50b4bc3fe3ed8d3ea85f834cec7d3R21-L49) [[3]](diffhunk://#diff-44e0997692527cdd0cfd415cb4ca4a4c15f89b3ac8623ba58fece1d1ae1da5f9R21-R48)
  - Updated workflows to inject environment variables and use `docker compose` with converted YAML files for builds and tests. [[1]](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2R21-R48) [[2]](diffhunk://#diff-5792fdfb83a2b96c0766446871965cbf84e50b4bc3fe3ed8d3ea85f834cec7d3R21-L49) [[3]](diffhunk://#diff-44e0997692527cdd0cfd415cb4ca4a4c15f89b3ac8623ba58fece1d1ae1da5f9R21-R48)

### New `docker-compose` Configuration Files

* Introduced `docker-compose.ci.e2e.yaml`, `docker-compose.ci.lighthouse.yaml`, and `docker-compose.ci.storybook.yaml`:
  - Defined services with build caching using `cache_from` and `cache_to` pointing to GitHub Container Registry. [[1]](diffhunk://#diff-31a868551a5e4d64856a2208227a8780e26c2f2c5b6201e1cdc96ffc0e63e635R1-R39) [[2]](diffhunk://#diff-6a56adb6c0d9bd5f7cd21db951118fda708b2420f37159c959c433050bbd747bR1-R41) [[3]](diffhunk://#diff-a3d151747cbb30f51b23f845302071a011b694bd65f497003cd845bbbbbacc45R1-R40)
  - Added external networks for container communication. [[1]](diffhunk://#diff-31a868551a5e4d64856a2208227a8780e26c2f2c5b6201e1cdc96ffc0e63e635R1-R39) [[2]](diffhunk://#diff-6a56adb6c0d9bd5f7cd21db951118fda708b2420f37159c959c433050bbd747bR1-R41) [[3]](diffhunk://#diff-a3d151747cbb30f51b23f845302071a011b694bd65f497003cd845bbbbbacc45R1-R40)

### Cleanup of Legacy Docker Compose Files

* Removed `cache_from` directives for outdated Docker images in `docker-compose.e2e.yaml`, `docker-compose.lighthouse.yaml`, and `docker-compose.storybook.yaml` to eliminate reliance on local caching. [[1]](diffhunk://#diff-474104dbb5418212a61a85ea05a9b807892747ce3a56db74d459d627a658a6c5L10-L11) [[2]](diffhunk://#diff-474104dbb5418212a61a85ea05a9b807892747ce3a56db74d459d627a658a6c5L22-L23) [[3]](diffhunk://#diff-55d496ee3d8c1cb039d145e681a7409d0d6bde701e18f4f994236f8d5183dc0eL10-L11) [[4]](diffhunk://#diff-55d496ee3d8c1cb039d145e681a7409d0d6bde701e18f4f994236f8d5183dc0eL22-L23) [[5]](diffhunk://#diff-ff11152d9ec2ad62eaec9092c286f82737b72db46ad19cc8d7649f9ce2422195L10-L11) [[6]](diffhunk://#diff-ff11152d9ec2ad62eaec9092c286f82737b72db46ad19cc8d7649f9ce2422195L22-L23)

closes #87 