### PR TITLE
프로젝트 루트 README 에서 더 이상 사용하지 않는 워크플로우에 대한 뱃지 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # 🗂️ Turborepo Template
 
-[![install-and-build](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/install-and-build.yml/badge.svg?event=push)](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/install-and-build.yml)
-[![unit-test](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/unit-test.yml/badge.svg?event=push)](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/unit-test.yml)
-[![storybook-test](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/storybook-test.yml/badge.svg?event=push)](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/storybook-test.yml)
-[![e2e-test](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/e2e-test.yml/badge.svg?event=push)](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/e2e-test.yml)
-[![lighthouse-test](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/lighthouse-test.yml/badge.svg?event=push)](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/lighthouse-test.yml)
+[![test](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/test.yml/badge.svg?event=push)](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/test.yml)
 [![Release](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/release.yml/badge.svg?event=push)](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/release.yml)
 
 ## 📖 개요


### PR DESCRIPTION
This pull request simplifies the badges in the `README.md` file by consolidating multiple workflow badges into a single badge for testing.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Replaced individual badges for `install-and-build`, `unit-test`, `storybook-test`, `e2e-test`, and `lighthouse-test` workflows with a single consolidated badge for the `test` workflow.