### PR TITLE
`cli` 도구들 중 `change-owner-name`과 `rename-repository` 명령어에서 일부 문자열들을 놓치는 문제 해결

### DIFF
--- a/tools/cli/src/utils/replaceAllInDirectory/index.ts
+++ b/tools/cli/src/utils/replaceAllInDirectory/index.ts
@@ -4,6 +4,11 @@ import getStdoutUpdater from "../getStdoutUpdater";
 import replaceInFile from "../replaceInFile";
 
 /**
+ * Files to include in the renaming process
+ */
+const FILES_TO_INCLUDE = ["LICENSE"];
+
+/**
  * Renames the scope of a package name in each file with the specified extension
  */
 const TARGET_EXTENSIONS = [
@@ -44,14 +49,16 @@ const EXCLUDE_DIRS = [
  * @param newString - The string to replace with
  * @param excludeDirs - Directories to exclude from the search
  * @param targetExtensions - File extensions to target for replacement
+ * @param filesToInclude - Files to include in the renaming process
  */
 export default function replaceAllInDirectory(
   rootDir: string,
   oldString: string,
   newString: string,
-  { excludeDirs, targetExtensions } = {
+  { excludeDirs, targetExtensions, filesToInclude } = {
     excludeDirs: EXCLUDE_DIRS,
     targetExtensions: TARGET_EXTENSIONS,
+    filesToInclude: FILES_TO_INCLUDE,
   },
 ) {
   const updateStdout = getStdoutUpdater();
@@ -70,6 +77,8 @@ export default function replaceAllInDirectory(
         targetExtensions.some((target) => ext.endsWith(target)) &&
         fullPath !== __filename
       ) {
+        replaceInFile(fullPath, oldString, newString);
+      } else if (filesToInclude.includes(entry.name)) {
         replaceInFile(fullPath, oldString, newString);
       }
     }

--- a/tools/cli/src/utils/replaceAllInDirectory/index.ts
+++ b/tools/cli/src/utils/replaceAllInDirectory/index.ts
@@ -6,7 +6,17 @@ import replaceInFile from "../replaceInFile";
 /**
  * Renames the scope of a package name in each file with the specified extension
  */
-const TARGET_EXTENSIONS = ["md", "json", "css", "ts", "tsx", "js", "jsx"];
+const TARGET_EXTENSIONS = [
+  "md",
+  "yml",
+  "yaml",
+  "json",
+  "css",
+  "ts",
+  "tsx",
+  "js",
+  "jsx",
+];
 
 /**
  * Directories to exclude from renaming

--- a/tools/cli/src/utils/replaceAllInDirectory/index.ts
+++ b/tools/cli/src/utils/replaceAllInDirectory/index.ts
@@ -25,7 +25,6 @@ const EXCLUDE_DIRS = [
   "node_modules",
   ".git",
   ".devcontainer",
-  ".github",
   ".husky",
   ".idea",
   ".turbo",


### PR DESCRIPTION
This pull request enhances the `replaceAllInDirectory` utility by introducing support for explicitly including specific files in the renaming process, expanding the target file extensions, and simplifying the exclusion logic. Below are the most important changes grouped by theme:

### Enhancements to file inclusion and targeting:

* Added a new constant, `FILES_TO_INCLUDE`, to specify files (e.g., `LICENSE`) that should always be included in the renaming process, regardless of their extension. Updated the function signature to accept this parameter. (`tools/cli/src/utils/replaceAllInDirectory/index.ts`, [[1]](diffhunk://#diff-3e27c113db0f1b7f11027a21fa07b00da53cdfdd6c264e297029db5a1a9ab52bR6-R24) [[2]](diffhunk://#diff-3e27c113db0f1b7f11027a21fa07b00da53cdfdd6c264e297029db5a1a9ab52bR52-R61)
* Expanded `TARGET_EXTENSIONS` to include YAML file extensions (`yml` and `yaml`) for broader compatibility. (`tools/cli/src/utils/replaceAllInDirectory/index.ts`, [tools/cli/src/utils/replaceAllInDirectory/index.tsR6-R24](diffhunk://#diff-3e27c113db0f1b7f11027a21fa07b00da53cdfdd6c264e297029db5a1a9ab52bR6-R24))

### Simplifications to exclusion logic:

* Removed `.github` from the `EXCLUDE_DIRS` list, allowing files in this directory to be processed. (`tools/cli/src/utils/replaceAllInDirectory/index.ts`, [tools/cli/src/utils/replaceAllInDirectory/index.tsL18](diffhunk://#diff-3e27c113db0f1b7f11027a21fa07b00da53cdfdd6c264e297029db5a1a9ab52bL18))

### Functional improvements:

* Updated the file processing logic to handle `FILES_TO_INCLUDE`, ensuring that explicitly included files are processed even if they do not match the target extensions. (`tools/cli/src/utils/replaceAllInDirectory/index.ts`, [tools/cli/src/utils/replaceAllInDirectory/index.tsR81-R82](diffhunk://#diff-3e27c113db0f1b7f11027a21fa07b00da53cdfdd6c264e297029db5a1a9ab52bR81-R82))