### PR TITLE
release 워크플로우가 실패하는 문제 해결

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,5 +71,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: pnpm version-packages
+          publish: pnpm publish-packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,10 @@ jobs:
         with:
           version: pnpm version-packages
           publish: pnpm publish-packages
+          commit: |
+            chore(release): 🦋 versioning packages by changesets
+          title: |
+            🦋 Versioning packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -182,6 +182,34 @@ Happy Hacking!
 
 이 프로젝트는 [Changesets](https://github.com/changesets/changesets)를 사용하여 패키지 버전 관리와 배포를 간소화하고 있어요. Changesets는 모노레포 환경에서 특히 유용하며, 각 패키지의 변경 사항을 추적하고 이를 기반으로 버전을 업데이트할 수 있도록 도와줘요.
 
+### changesets 봇 사용을 위한 설정
+
+changesets 봇을 사용하기 위해서는 GitHub 레포지토리의 설정을 변경해야 해요. \
+이 설정은 Changesets 봇이 PR을 생성하고, 변경 사항을 자동으로 추적할 수 있도록 해줘요. \
+이 설정을 통해 Changesets 봇이 PR을 생성하고, 변경 사항을 자동으로 추적할 수 있어요. \
+아래의 단계를 따라 주세요:
+
+1. GitHub 레포지토리 페이지로 이동해요.
+2. `Settings` 탭을 클릭해요.
+3. `Actions` 섹션으로 가요.
+4. `General`을 선택해요.
+5. Workflow Permissions에서 `Read repository contents permission`을 `Read and write permissions`로 변경해요.
+6. 그리고 `Allow GitHub Actions to create and approve pull requests`를 체크해요.
+7. `Save` 버튼을 클릭해요.
+
+### npm 배포를 위한 토큰 설정
+
+프로젝트의 secret 변수에 `NPM_TOKEN`을 설정해야 해요. \
+이 토큰은 npm에 패키지를 배포하는 데 사용돼요. \
+GitHub Secrets에 `NPM_TOKEN`을 추가하려면 아래의 단계를 따라 주세요:
+
+1. GitHub 레포지토리 페이지로 이동해요.
+2. `Settings` 탭을 클릭해요.
+3. `Secrets and variables` 섹션으로 가요.
+4. `Actions`를 선택해요.
+5. `New repository secret` 버튼을 클릭해요.
+6. [npm](https://www.npmjs.com/)에서 발급받은 토큰을 `NPM_TOKEN`이라는 이름으로 추가해요.
+
 ### 기본 사용 방법
 
 1. 새 변경 사항 추가:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pnpm install
 
 ### 소유자 ID 변경
 
-코드베이스 내 모든 파일을 탐색하여 기존의 소유자 ID 가 기록되어 있는 부분을 변경해요. \
+코드베이스 내 모든 파일을 탐색하여 기존의 소유자 ID 가 기록되어 있는 부분을 변경해요.
 코드에 대한 보다 자세한 내용은 [`tools/cli`의 README](./tools/cli/README.md#-제공-기능)를 참고해 주세요.
 
 ```bash
@@ -91,7 +91,7 @@ change-owner-name --name your-username
 
 ### 레포지토리 이름 변경
 
-코드 베이스 내 모든 파일을 탐색하여 기존의 레포지토리 이름이 기록되어 있는 부분을 변경해요. \
+코드 베이스 내 모든 파일을 탐색하여 기존의 레포지토리 이름이 기록되어 있는 부분을 변경해요.
 코드에 대한 보다 자세한 내용은 [`tools/cli`의 README](./tools/cli/README.md#-제공-기능)를 참고해 주세요.
 
 ```bash
@@ -100,8 +100,8 @@ rename-repository --name new-repository-name
 
 ### 스코프 이름 변경
 
-코드 베이스 내 모든 파일을 탐색하여 기존의 스코프 이름이 기록되어 있는 부분을 변경해요. \
-만약 모노레포 내 일부 구성 요소들을 [npm](https://www.npmjs.com/) 의 특정 스코프(e.g. `new-scope-name`)로 배포해야 해서 해당 스코프 이름으로 변경해야 하는 경우에 유용할 거예요. \
+코드 베이스 내 모든 파일을 탐색하여 기존의 스코프 이름이 기록되어 있는 부분을 변경해요.
+만약 모노레포 내 일부 구성 요소들을 [npm](https://www.npmjs.com/) 의 특정 스코프(e.g. `new-scope-name`)로 배포해야 해서 해당 스코프 이름으로 변경해야 하는 경우에 유용할 거예요.
 코드에 대한 보다 자세한 내용은 [`tools/cli`의 README](./tools/cli/README.md#-제공-기능)를 참고해 주세요.
 
 ```bash
@@ -184,9 +184,8 @@ Happy Hacking!
 
 ### changesets 봇 사용을 위한 설정
 
-changesets 봇을 사용하기 위해서는 GitHub 레포지토리의 설정을 변경해야 해요. \
-이 설정은 Changesets 봇이 PR을 생성하고, 변경 사항을 자동으로 추적할 수 있도록 해줘요. \
-이 설정을 통해 Changesets 봇이 PR을 생성하고, 변경 사항을 자동으로 추적할 수 있어요. \
+changesets 봇을 사용하기 위해서는 GitHub 레포지토리의 설정을 변경해야 해요.
+이 설정을 통해 Changesets 봇이 PR을 생성하고, 변경 사항을 자동으로 추적할 수 있어요.
 아래의 단계를 따라 주세요:
 
 1. GitHub 레포지토리 페이지로 이동해요.
@@ -199,8 +198,8 @@ changesets 봇을 사용하기 위해서는 GitHub 레포지토리의 설정을 
 
 ### npm 배포를 위한 토큰 설정
 
-프로젝트의 secret 변수에 `NPM_TOKEN`을 설정해야 해요. \
-이 토큰은 npm에 패키지를 배포하는 데 사용돼요. \
+프로젝트의 secret 변수에 `NPM_TOKEN`을 설정해야 해요.
+이 토큰은 npm에 패키지를 배포하는 데 사용돼요.
 GitHub Secrets에 `NPM_TOKEN`을 추가하려면 아래의 단계를 따라 주세요:
 
 1. GitHub 레포지토리 페이지로 이동해요.


### PR DESCRIPTION
This pull request introduces updates to streamline package versioning and deployment using Changesets. Key changes include modifications to the release workflow to support npm publishing and updates to the `README.md` to guide users on configuring Changesets and npm deployment.

### Workflow updates for versioning and deployment:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R74-R81): Added `pnpm publish-packages` for publishing, a commit message template for versioning, and support for `NPM_TOKEN` to enable secure npm deployment.

### Documentation enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R185-R212): Added detailed instructions for configuring Changesets bot and setting up `NPM_TOKEN` in GitHub Secrets to facilitate automated versioning and npm package deployment.