### PR TITLE
release 워크플로우 실패 해결을 위해 eslint 검사 대상 디렉토리에서 coverage 제외

### DIFF
--- a/configs/eslint-config/base.js
+++ b/configs/eslint-config/base.js
@@ -29,7 +29,7 @@ export const config = [
     },
   },
   {
-    ignores: ["dist/**"],
+    ignores: ["dist/**", "coverage/**"],
   },
   {
     languageOptions: {


### PR DESCRIPTION
This pull request updates the ESLint configuration to include an additional directory in the ignored paths.

* [`configs/eslint-config/base.js`](diffhunk://#diff-f940d232f8c20557ba23c06e5514ae8ebe1cca954c97924bc27b3d78b7c0b337L32-R32): Updated the `ignores` array in the ESLint configuration to also ignore the `coverage/**` directory, in addition to `dist/**`.