### PR TITLE
test 워크플로우에서 docker-compose 를 이용하는 job 에 사용되는 이미지 레이어 캐시 저장 경로 변경

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,6 +135,7 @@ jobs:
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
 
   lighthouse-test:
     needs: set-docker-compose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,8 +123,9 @@ jobs:
         with:
           path: |
             docker-compose.gha.converted.yaml
-          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           restore-keys: |
+            ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-
             ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-
             ${{ runner.os }}-docker-compose-
       - name: Set up Docker Build
@@ -148,8 +149,9 @@ jobs:
         with:
           path: |
             docker-compose.gha.converted.yaml
-          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           restore-keys: |
+            ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-
             ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-
             ${{ runner.os }}-docker-compose-
       - name: Login to GitHub Container Registry
@@ -176,8 +178,9 @@ jobs:
         with:
           path: |
             docker-compose.gha.converted.yaml
-          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           restore-keys: |
+            ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-
             ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-
             ${{ runner.os }}-docker-compose-
       - name: Login to GitHub Container Registry
@@ -218,8 +221,9 @@ jobs:
         with:
           path: |
             docker-compose.gha.converted.yaml
-          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           restore-keys: |
+            ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-
             ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-
             ${{ runner.os }}-docker-compose-
       - name: Login to GitHub Container Registry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,7 @@ jobs:
       - name: inject environment variables
         run: |
           docker compose -f docker-compose.gha.yaml convert > docker-compose.gha.converted.yaml
+          cat docker-compose.gha.converted.yaml
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/docker-compose.gha.yaml
+++ b/docker-compose.gha.yaml
@@ -14,9 +14,9 @@ services:
       context: .
       dockerfile: ./apps/web/Dockerfile
       cache_from:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/web:cache
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-web:cache
       cache_to:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/web:cache,mode=max
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-web:cache,mode=max
     ports:
       - 3000:3000
     networks:
@@ -28,9 +28,9 @@ services:
       context: .
       dockerfile: ./tools/playwright-web/Dockerfile
       cache_from:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/playwright-web:cache
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-playwright-web:cache
       cache_to:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/playwright-web:cache,mode=max
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-playwright-web:cache,mode=max
     networks:
       - test_network
     depends_on:
@@ -44,9 +44,9 @@ services:
       context: .
       dockerfile: ./tools/lighthouse-ci/Dockerfile
       cache_from:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/lighthouse-runner:cache
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-lighthouse-runner:cache
       cache_to:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/lighthouse-runner:cache,mode=max
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-lighthouse-runner:cache,mode=max
     networks:
       - test_network
     depends_on:
@@ -62,9 +62,9 @@ services:
       context: .
       dockerfile: ./apps/frontend-workshop/Dockerfile
       cache_from:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/storybook:cache
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-storybook:cache
       cache_to:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/storybook:cache,mode=max
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-storybook:cache,mode=max
     ports:
       - 6006:80
     networks:
@@ -76,9 +76,9 @@ services:
       context: .
       dockerfile: ./apps/frontend-workshop/Dockerfile.test-runner
       cache_from:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/storybook-test-runner:cache
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-storybook-test-runner:cache
       cache_to:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/storybook-test-runner:cache,mode=max
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-storybook-test-runner:cache,mode=max
     networks:
       - test_network
     depends_on:


### PR DESCRIPTION
This pull request introduces changes to improve cache key specificity and organization by incorporating the repository name into various workflows and Docker Compose configurations. The updates ensure that cache keys and image references are unique per repository, reducing potential conflicts in multi-repository setups.

### Workflow Updates
* Updated cache keys in `.github/workflows/test.yml` to include `${{ github.event.repository.name }}`, ensuring cache keys are unique per repository. This change affects multiple jobs in the workflow. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L126-R128) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L150-R154) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L178-R183) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L220-R226)
* Added a new environment variable, `REPOSITORY_NAME`, to the workflow to pass the repository name to subsequent steps.

### Docker Compose Updates
* Updated `docker-compose.gha.yaml` to include `${REPOSITORY_NAME}` in `cache_from` and `cache_to` references for all services. This ensures that Docker image caches are uniquely tagged per repository:
  - `web` service
  - `playwright-web` service
  - `lighthouse-runner` service
  - `storybook` service
  - `storybook-test-runner` service