### PR TITLE
`eslint-plugin-sample` 패키지에서 name 필드의 스코프가 잘못 설정되어 있던 부분 수정

### DIFF
--- a/packages/eslint-plugin-sample/package.json
+++ b/packages/eslint-plugin-sample/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@iamhoonse/eslint-plugin-sample",
+  "name": "@repo/eslint-plugin-sample",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This pull request includes a minor change to the `packages/eslint-plugin-sample/package.json` file. The change updates the package name from `@iamhoonse/eslint-plugin-sample` to `@repo/eslint-plugin-sample` to align with the repository's naming conventions.