### PR TITLE
`test.yml` 워크플로우에서 각 docker-compose 기반 테스트에 사용되는 레지스트리 경로가 잘못된 부분 수정

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,6 +167,9 @@ jobs:
       - name: Build Lighthouse images
         run: |
           docker compose -f docker-compose.gha.converted.yaml build web lighthouse-runner
+      - name: Push Lighthouse images
+        run: |
+          docker compose -f docker-compose.gha.converted.yaml push web lighthouse-runner --ignore-push-failures
       - name: Run Lighthouse tests
         run: |
           docker compose -f docker-compose.gha.converted.yaml up web lighthouse-runner --exit-code-from lighthouse-runner
@@ -199,6 +202,9 @@ jobs:
       - name: Build E2E images
         run: |
           docker compose -f docker-compose.gha.converted.yaml build web playwright-web
+      - name: Push E2E images
+        run: |
+          docker compose -f docker-compose.gha.converted.yaml push web playwright-web --ignore-push-failures
       - name: Run E2E tests for web
         run: |
           docker compose -f docker-compose.gha.converted.yaml up web playwright-web --exit-code-from playwright-web
@@ -245,6 +251,9 @@ jobs:
       - name: Build Storybook images
         run: |
           docker compose -f docker-compose.gha.converted.yaml build storybook storybook-test-runner
+      - name: Push Storybook images
+        run: |
+          docker compose -f docker-compose.gha.converted.yaml push storybook storybook-test-runner --ignore-push-failures
       - name: Run Storybook tests
         run: |
           docker compose -f docker-compose.gha.converted.yaml up storybook storybook-test-runner --exit-code-from storybook-test-runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,7 +166,7 @@ jobs:
           docker network inspect "test_network" >/dev/null 2>&1 || docker network create "test_network"
       - name: Build Lighthouse images
         run: |
-          docker compose -f docker-compose.gha.converted.yaml build web lighthouse-runner
+          docker compose -f docker-compose.gha.converted.yaml build web lighthouse-runner --push
       - name: Run Lighthouse tests
         run: |
           docker compose -f docker-compose.gha.converted.yaml up web lighthouse-runner --exit-code-from lighthouse-runner
@@ -198,7 +198,7 @@ jobs:
           docker network inspect "test_network" >/dev/null 2>&1 || docker network create "test_network"
       - name: Build E2E images
         run: |
-          docker compose -f docker-compose.gha.converted.yaml build web playwright-web
+          docker compose -f docker-compose.gha.converted.yaml build web playwright-web --push
       - name: Run E2E tests for web
         run: |
           docker compose -f docker-compose.gha.converted.yaml up web playwright-web --exit-code-from playwright-web
@@ -244,7 +244,7 @@ jobs:
           docker network inspect "test_network" >/dev/null 2>&1 || docker network create "test_network"
       - name: Build Storybook images
         run: |
-          docker compose -f docker-compose.gha.converted.yaml build storybook storybook-test-runner
+          docker compose -f docker-compose.gha.converted.yaml build storybook storybook-test-runner --push
       - name: Run Storybook tests
         run: |
           docker compose -f docker-compose.gha.converted.yaml up storybook storybook-test-runner --exit-code-from storybook-test-runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -242,7 +242,7 @@ jobs:
       - name: Prepare docker external network
         run: |
           docker network inspect "test_network" >/dev/null 2>&1 || docker network create "test_network"
-      - name: Build Storybook image
+      - name: Build Storybook images
         run: |
           docker compose -f docker-compose.gha.converted.yaml build storybook storybook-test-runner
       - name: Run Storybook tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,6 +164,9 @@ jobs:
       - name: Prepare docker external network
         run: |
           docker network inspect "test_network" >/dev/null 2>&1 || docker network create "test_network"
+      - name: Build Lighthouse images
+        run: |
+          docker compose -f docker-compose.gha.converted.yaml build web lighthouse-runner
       - name: Run Lighthouse tests
         run: |
           docker compose -f docker-compose.gha.converted.yaml up web lighthouse-runner --exit-code-from lighthouse-runner
@@ -193,6 +196,9 @@ jobs:
       - name: Prepare docker external network
         run: |
           docker network inspect "test_network" >/dev/null 2>&1 || docker network create "test_network"
+      - name: Build E2E images
+        run: |
+          docker compose -f docker-compose.gha.converted.yaml build web playwright-web
       - name: Run E2E tests for web
         run: |
           docker compose -f docker-compose.gha.converted.yaml up web playwright-web --exit-code-from playwright-web
@@ -236,6 +242,9 @@ jobs:
       - name: Prepare docker external network
         run: |
           docker network inspect "test_network" >/dev/null 2>&1 || docker network create "test_network"
+      - name: Build Storybook image
+        run: |
+          docker compose -f docker-compose.gha.converted.yaml build storybook storybook-test-runner
       - name: Run Storybook tests
         run: |
           docker compose -f docker-compose.gha.converted.yaml up storybook storybook-test-runner --exit-code-from storybook-test-runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,8 +123,9 @@ jobs:
         with:
           path: |
             docker-compose.gha.converted.yaml
-          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}-${{ hashFiles('**/docker-compose.gha.yaml') }}
           restore-keys: |
+            ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}-
             ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-
             ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-
             ${{ runner.os }}-docker-compose-
@@ -150,8 +151,9 @@ jobs:
         with:
           path: |
             docker-compose.gha.converted.yaml
-          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}-${{ hashFiles('**/docker-compose.gha.yaml') }}
           restore-keys: |
+            ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}-
             ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-
             ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-
             ${{ runner.os }}-docker-compose-
@@ -185,8 +187,9 @@ jobs:
         with:
           path: |
             docker-compose.gha.converted.yaml
-          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}-${{ hashFiles('**/docker-compose.gha.yaml') }}
           restore-keys: |
+            ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}-
             ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-
             ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-
             ${{ runner.os }}-docker-compose-
@@ -234,8 +237,9 @@ jobs:
         with:
           path: |
             docker-compose.gha.converted.yaml
-          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          key: ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}-${{ hashFiles('**/docker-compose.gha.yaml') }}
           restore-keys: |
+            ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ secrets.LHCI_GITHUB_APP_TOKEN }}-
             ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-${{ github.event.repository.name }}-
             ${{ runner.os }}-docker-compose-${{ github.repository_owner }}-
             ${{ runner.os }}-docker-compose-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,7 +166,7 @@ jobs:
           docker network inspect "test_network" >/dev/null 2>&1 || docker network create "test_network"
       - name: Build Lighthouse images
         run: |
-          docker compose -f docker-compose.gha.converted.yaml build web lighthouse-runner --push
+          docker compose -f docker-compose.gha.converted.yaml build web lighthouse-runner
       - name: Run Lighthouse tests
         run: |
           docker compose -f docker-compose.gha.converted.yaml up web lighthouse-runner --exit-code-from lighthouse-runner
@@ -198,7 +198,7 @@ jobs:
           docker network inspect "test_network" >/dev/null 2>&1 || docker network create "test_network"
       - name: Build E2E images
         run: |
-          docker compose -f docker-compose.gha.converted.yaml build web playwright-web --push
+          docker compose -f docker-compose.gha.converted.yaml build web playwright-web
       - name: Run E2E tests for web
         run: |
           docker compose -f docker-compose.gha.converted.yaml up web playwright-web --exit-code-from playwright-web
@@ -244,7 +244,7 @@ jobs:
           docker network inspect "test_network" >/dev/null 2>&1 || docker network create "test_network"
       - name: Build Storybook images
         run: |
-          docker compose -f docker-compose.gha.converted.yaml build storybook storybook-test-runner --push
+          docker compose -f docker-compose.gha.converted.yaml build storybook storybook-test-runner
       - name: Run Storybook tests
         run: |
           docker compose -f docker-compose.gha.converted.yaml up storybook storybook-test-runner --exit-code-from storybook-test-runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,9 +169,6 @@ jobs:
       - name: Build Lighthouse images
         run: |
           docker compose -f docker-compose.gha.converted.yaml build web lighthouse-runner
-      - name: Push Lighthouse images
-        run: |
-          docker compose -f docker-compose.gha.converted.yaml push web lighthouse-runner --ignore-push-failures
       - name: Run Lighthouse tests
         run: |
           docker compose -f docker-compose.gha.converted.yaml up web lighthouse-runner --exit-code-from lighthouse-runner
@@ -205,9 +202,6 @@ jobs:
       - name: Build E2E images
         run: |
           docker compose -f docker-compose.gha.converted.yaml build web playwright-web
-      - name: Push E2E images
-        run: |
-          docker compose -f docker-compose.gha.converted.yaml push web playwright-web --ignore-push-failures
       - name: Run E2E tests for web
         run: |
           docker compose -f docker-compose.gha.converted.yaml up web playwright-web --exit-code-from playwright-web
@@ -255,9 +249,6 @@ jobs:
       - name: Build Storybook images
         run: |
           docker compose -f docker-compose.gha.converted.yaml build storybook storybook-test-runner
-      - name: Push Storybook images
-        run: |
-          docker compose -f docker-compose.gha.converted.yaml push storybook storybook-test-runner --ignore-push-failures
       - name: Run Storybook tests
         run: |
           docker compose -f docker-compose.gha.converted.yaml up storybook storybook-test-runner --exit-code-from storybook-test-runner

--- a/docker-compose.gha.yaml
+++ b/docker-compose.gha.yaml
@@ -10,14 +10,14 @@ networks:
 services:
   # The web service is built from the Dockerfile located in the ./apps/web directory
   web:
-    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-web:cache
+    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/web:cache
     build:
       context: .
       dockerfile: ./apps/web/Dockerfile
       cache_from:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-web:cache
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/web:cache
       cache_to:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-web:cache,mode=max
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/web:cache,mode=max
     ports:
       - 3000:3000
     networks:
@@ -25,14 +25,14 @@ services:
 
   # The Playwright service is built from the Dockerfile located in the ./tools/playwright directory
   playwright-web:
-    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-playwright-web:cache
+    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/playwright-web:cache
     build:
       context: .
       dockerfile: ./tools/playwright-web/Dockerfile
       cache_from:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-playwright-web:cache
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/playwright-web:cache
       cache_to:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-playwright-web:cache,mode=max
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/playwright-web:cache,mode=max
     networks:
       - test_network
     depends_on:
@@ -42,14 +42,14 @@ services:
 
   # The Lighthouse CI service is built from the Dockerfile located in the ./tools/lighthouse-ci directory
   lighthouse-runner:
-    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-lighthouse-runner:cache
+    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/lighthouse-runner:cache
     build:
       context: .
       dockerfile: ./tools/lighthouse-ci/Dockerfile
       cache_from:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-lighthouse-runner:cache
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/lighthouse-runner:cache
       cache_to:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-lighthouse-runner:cache,mode=max
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/lighthouse-runner:cache,mode=max
     networks:
       - test_network
     depends_on:
@@ -61,14 +61,14 @@ services:
 
   # The frontend-workshop service is built from the Dockerfile located in the ./apps/frontend-workshop directory
   storybook:
-    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-storybook:cache
+    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/storybook:cache
     build:
       context: .
       dockerfile: ./apps/frontend-workshop/Dockerfile
       cache_from:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-storybook:cache
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/storybook:cache
       cache_to:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-storybook:cache,mode=max
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/storybook:cache,mode=max
     ports:
       - 6006:80
     networks:
@@ -76,14 +76,14 @@ services:
 
   # The frontend-workshop-test-runner service is built from the Dockerfile located in the ./apps/frontend-workshop directory
   storybook-test-runner:
-    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-storybook-test-runner:cache
+    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/storybook-test-runner:cache
     build:
       context: .
       dockerfile: ./apps/frontend-workshop/Dockerfile.test-runner
       cache_from:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-storybook-test-runner:cache
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/storybook-test-runner:cache
       cache_to:
-        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-storybook-test-runner:cache,mode=max
+        - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/storybook-test-runner:cache,mode=max
     networks:
       - test_network
     depends_on:

--- a/docker-compose.gha.yaml
+++ b/docker-compose.gha.yaml
@@ -10,6 +10,7 @@ networks:
 services:
   # The web service is built from the Dockerfile located in the ./apps/web directory
   web:
+    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-web:cache
     build:
       context: .
       dockerfile: ./apps/web/Dockerfile
@@ -24,6 +25,7 @@ services:
 
   # The Playwright service is built from the Dockerfile located in the ./tools/playwright directory
   playwright-web:
+    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-playwright-web:cache
     build:
       context: .
       dockerfile: ./tools/playwright-web/Dockerfile
@@ -40,6 +42,7 @@ services:
 
   # The Lighthouse CI service is built from the Dockerfile located in the ./tools/lighthouse-ci directory
   lighthouse-runner:
+    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-lighthouse-runner:cache
     build:
       context: .
       dockerfile: ./tools/lighthouse-ci/Dockerfile
@@ -58,6 +61,7 @@ services:
 
   # The frontend-workshop service is built from the Dockerfile located in the ./apps/frontend-workshop directory
   storybook:
+    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-storybook:cache
     build:
       context: .
       dockerfile: ./apps/frontend-workshop/Dockerfile
@@ -72,6 +76,7 @@ services:
 
   # The frontend-workshop-test-runner service is built from the Dockerfile located in the ./apps/frontend-workshop directory
   storybook-test-runner:
+    image: ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}-storybook-test-runner:cache
     build:
       context: .
       dockerfile: ./apps/frontend-workshop/Dockerfile.test-runner


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/test.yml` to include explicit Docker image build steps for various testing stages. These changes ensure that the necessary images are built before running tests, improving the reliability and reproducibility of the workflow.

### Updates to GitHub Actions workflow:

* **Lighthouse Tests:**
  - Added a step to build the `web` and `lighthouse-runner` Docker images before running Lighthouse tests.
  
* **End-to-End (E2E) Tests:**
  - Added a step to build the `web` and `playwright-web` Docker images before running E2E tests.
  
* **Storybook Tests:**
  - Added a step to build the `storybook` and `storybook-test-runner` Docker images before running Storybook tests.