### PR TITLE
docker-compose 설정 구성에서 컨테이너마다 불필요한 포트 포워딩 설정 제거

### DIFF
--- a/docker-compose.gha.yaml
+++ b/docker-compose.gha.yaml
@@ -18,8 +18,6 @@ services:
         - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/web:cache
       cache_to:
         - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/web:cache,mode=max
-    ports:
-      - 3000:3000
     networks:
       - test_network
 

--- a/docker-compose.gha.yaml
+++ b/docker-compose.gha.yaml
@@ -67,8 +67,6 @@ services:
         - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/storybook:cache
       cache_to:
         - type=registry,ref=ghcr.io/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/storybook:cache,mode=max
-    ports:
-      - 6006:80
     networks:
       - test_network
 


### PR DESCRIPTION
This pull request modifies the `docker-compose.gha.yaml` file to remove unnecessary port mappings for the `web` and `storybook` services. These changes simplify the configuration by eliminating unused or redundant settings.

### Configuration simplifications:

* Removed the `3000:3000` port mapping from the `web` service configuration. (`docker-compose.gha.yaml`, [docker-compose.gha.yamlL21-L22](diffhunk://#diff-7ff6ffd46496cd6516a2705241fd85dcbb7c40bf6b988c866e6888a2dd047551L21-L22))
* Removed the `6006:80` port mapping from the `storybook` service configuration. (`docker-compose.gha.yaml`, [docker-compose.gha.yamlL72-L73](diffhunk://#diff-7ff6ffd46496cd6516a2705241fd85dcbb7c40bf6b988c866e6888a2dd047551L72-L73))