### PR TITLE
`frontend-workshop`(Storybook) 앱에서 TailwindCSS 의 breakpoints 별 뷰포트를 볼 수 있도록 설정

### DIFF
--- a/apps/frontend-workshop/.storybook/preview.ts
+++ b/apps/frontend-workshop/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from "@storybook/react";
+import { breakpoints } from "@repo/react-ui/constants";
 import "@repo/react-ui/base.css";
 
 const preview: Preview = {
@@ -7,6 +8,47 @@ const preview: Preview = {
       matchers: {
         color: /(background|color)$/i,
         date: /Date$/i,
+      },
+    },
+
+    // 뷰포트 목록
+    viewport: {
+      viewports: {
+        tailwindSmall: {
+          name: "Tailwind Small",
+          styles: {
+            width: breakpoints.sm,
+            height: "100%",
+          },
+        },
+        tailwindMedium: {
+          name: "Tailwind Medium",
+          styles: {
+            width: breakpoints.md,
+            height: "100%",
+          },
+        },
+        tailwindLarge: {
+          name: "Tailwind Large",
+          styles: {
+            width: breakpoints.lg,
+            height: "100%",
+          },
+        },
+        tailwindXLarge: {
+          name: "Tailwind Extra Large",
+          styles: {
+            width: breakpoints.xl,
+            height: "100%",
+          },
+        },
+        tailwindXXLarge: {
+          name: "Tailwind 2XL",
+          styles: {
+            width: breakpoints["2xl"],
+            height: "100%",
+          },
+        },
       },
     },
 

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -47,6 +47,11 @@
       "import": "./dist/components/index.es.js",
       "require": "./dist/components/index.cjs.js"
     },
+    "./constants": {
+      "types": "./dist/constants/index.d.ts",
+      "import": "./dist/constants/index.es.js",
+      "require": "./dist/constants/index.cjs.js"
+    },
     "./base.css": "./dist/styles/base.css"
   },
   "files": [

--- a/packages/react-ui/src/constants/breakpoints/index.ts
+++ b/packages/react-ui/src/constants/breakpoints/index.ts
@@ -1,0 +1,3 @@
+import defaultTheme from "tailwindcss/defaultTheme";
+
+export default defaultTheme.screens;

--- a/packages/react-ui/src/constants/index.ts
+++ b/packages/react-ui/src/constants/index.ts
@@ -1,0 +1,6 @@
+/* v8 ignore start */
+
+/* breakpoints */
+export { default as breakpoints } from "@/constants/breakpoints";
+
+/* v8 ignore stop */

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -25,6 +25,8 @@ const fileName: Exclude<LibraryOptions["fileName"], string> = (
       return `lib/utils.${format}.js`;
     case "components":
       return `components/index.${format}.js`;
+    case "constants":
+      return `constants/index.${format}.js`;
     case "styles":
       return `styles/index.${format}.js`;
     default:


### PR DESCRIPTION
This pull request introduces support for responsive design breakpoints in the Storybook configuration of the `frontend-workshop` app and adds a new `constants` module to the `react-ui` package to centralize and expose reusable constants like Tailwind breakpoints. Below is a breakdown of the most important changes:

### Storybook Enhancements
* Added a `viewport` configuration to the Storybook `preview.ts` file, defining custom viewports (`tailwindSmall`, `tailwindMedium`, `tailwindLarge`, `tailwindXLarge`, `tailwindXXLarge`) based on Tailwind CSS breakpoints. This enables testing components in different responsive layouts.
* Imported the `breakpoints` constant from the new `constants` module in `@repo/react-ui` to define these custom viewports.

### `react-ui` Package Updates
* Added a new `constants` export in the `package.json` file to expose the `constants` module, including its type definitions and build artifacts.
* Created a `breakpoints` module in `src/constants/breakpoints` that exports Tailwind's default screen sizes as breakpoints.
* Updated the `src/constants/index.ts` file to re-export the `breakpoints` module, making it accessible via `@/constants/breakpoints`.
* Modified the `vite.config.ts` file to include a build configuration for the new `constants` module.