### PR TITLE
프로젝트 루트 README 에 GitHub Pages 배포 설정 안내 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,6 @@ Happy Hacking!
 
 [`publish-gh-pages.yml`](.github/workflows/publish-gh-pages.yml) 파일에 정의되어 있으며, [`docs`](./apps/docs) 앱을 GitHub Pages에 배포해요.
 
-## 📖 GitHub Pages 사용
-
-이 프로젝트는 GitHub Pages를 사용해서 [`docs`](./apps/docs) 앱을 배포하고 있어요.
-배포된 문서는 아래 링크에서 확인할 수 있어요.
-
-[GitHub Pages 문서 보러 가기](https://iamhoonse-dev.github.io/turborepo-template/)
-
 ## 🐳 GitHub Container Registry 사용
 
 일부 `docker-compose` 기반 워크플로우(예: Storybook, E2E, Lighthouse 테스트)에서는 Docker 이미지 빌드 시 [GitHub Container Registry(GHCR)](https://ghcr.io/)를 활용해서 이미지 레이어를 캐싱해요.  
@@ -211,6 +204,21 @@ Happy Hacking!
 > 관련 설정은 각 워크플로우의 `.yaml` 파일과 `docker-compose.*.yaml` 파일에서 확인할 수 있어요.
 >
 > - [`.github/workflows`](.github/workflows/)
+
+## 📖 GitHub Pages 사용
+
+이 프로젝트는 GitHub Pages를 사용해서 [`docs`](./apps/docs) 앱을 배포하고 있어요.
+GitHub Pages 배포가 정상적으로 동작하려면 Settings에서 Pages를 활성화해야 해요.
+절차는 다음과 같아요:
+
+1. GitHub 레포지토리 페이지로 이동해요.
+2. `Settings` 탭을 클릭해요.
+3. `Pages` 섹션으로 가요.
+4. `Build and deployment`에서 `Source`를 `GitHub Actions`로 설정해요.
+
+배포된 문서의 URL 은 다음과 같은 구조를 가져요:
+
+> [https://<USER_ID>.github.io/<PROJECT_NAME>](https://iamhoonse-dev.github.io/turborepo-template/)
 
 ## 🗼 Lighthouse CI GitHub App 사용
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![test](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/test.yml/badge.svg?event=push)](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/test.yml)
 [![Release](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/release.yml/badge.svg?event=push)](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/release.yml)
+[![publish-github-pages](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/publish-github-pages.yml/badge.svg)](https://github.com/iamhoonse-dev/turborepo-template/actions/workflows/publish-github-pages.yml)
 
 ## 📖 개요
 


### PR DESCRIPTION
This pull request updates the `README.md` file to include information about publishing the `docs` app to GitHub Pages and provides detailed instructions for enabling GitHub Pages in the repository settings. Additionally, it adds a badge for the GitHub Pages workflow.

### Updates related to GitHub Pages:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5): Added a badge for the GitHub Pages workflow to the top of the file, showcasing the status of the `publish-github-pages.yml` workflow.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R208-R222): Reorganized and expanded the section on GitHub Pages usage, including step-by-step instructions for enabling Pages in repository settings and clarifying the structure of the deployment URL. This replaces the previous, shorter explanation.