### PR TITLE
`release` 워크플로우가 간헐적으로 실패하던 문제 해결

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Build Packages
         run: pnpm run build
 
+      - name: Run Tests
+        run: pnpm run test
+
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "view-report": "turbo run view-report",
     "merge-json-reports": "turbo run merge-json-reports",
     "prepare": "husky",
-    "version-packages": "turbo run build lint test && changeset version",
-    "publish-packages": "turbo run build lint test && changeset version && changeset publish"
+    "version-packages": "changeset version",
+    "publish-packages": "changeset version && changeset publish"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.0",


### PR DESCRIPTION
This pull request introduces changes to streamline the release process and ensure tests are run during the package build workflow. The most important updates include adding a test step to the GitHub Actions workflow and simplifying the `version-packages` and `publish-packages` scripts in `package.json`.

### Workflow improvements:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R74-R76): Added a step to run tests (`pnpm run test`) as part of the release workflow to ensure package integrity before creating a release pull request.

### Script simplifications:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L21-R22): Removed redundant `build`, `lint`, and `test` commands from the `version-packages` and `publish-packages` scripts, relying solely on `changeset` commands for versioning and publishing.