### PR TITLE
docs 앱에서 각 문서와 댓글 영역 사이의 간격 상향 조정

### DIFF
--- a/apps/docs/app/[locale]/[[...mdxPath]]/page.tsx
+++ b/apps/docs/app/[locale]/[[...mdxPath]]/page.tsx
@@ -33,6 +33,7 @@ export default async function Page(props: Props) {
   return (
     <Wrapper toc={toc} metadata={metadata}>
       <MDXContent {...props} params={params} />
+      <hr style={{ margin: "2rem", opacity: "0" }} />
       <GiscusCommentsContainer
         repo={process.env.GISCUS_REPO}
         repoId={process.env.GISCUS_REPO_ID}


### PR DESCRIPTION
This pull request introduces a minor visual adjustment to the `Page` component in the `apps/docs` application. It adds a horizontal rule (`<hr>`) with specific styling to improve spacing and layout.

* `apps/docs/app/[locale]/[[...mdxPath]]/page.tsx`: Added a horizontal rule (`<hr>`) with a margin of `2rem` and opacity set to `0` for spacing purposes within the `Page` component. ([apps/docs/app/[locale]/[[...mdxPath]]/page.tsxR36](diffhunk://#diff-a6c8a2f644b90f4e6ababaae837c10f7f7431671cb664510d07b91267605d798R36))