### PR TITLE
`docs` 앱에 언어 로케일이 반영된 링크를 제공하는 카드 컴포넌트 추가

### DIFF
--- a/apps/docs/components/LocalizedCard/index.tsx
+++ b/apps/docs/components/LocalizedCard/index.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import type { ComponentProps, FC } from "react";
+import { Cards } from "nextra/components";
+import useLocalizedHref from "../../hooks/useLocalizedHref";
+
+type Props = ComponentProps<typeof Cards.Card>;
+
+/**
+ * LocalizedCard is a component that wraps Nextra's Card component
+ * and automatically prepends the current locale to the href.
+ *
+ * @param href
+ * @param cardProps
+ */
+const LocalizedCard: FC<Props> = ({ href, ...cardProps }) => {
+  // Use the custom hook to get the localized href based on the current locale
+  const localizedHref = useLocalizedHref(href);
+
+  // render the Card component with the localized href
+  return <Cards.Card {...cardProps} href={localizedHref} />;
+};
+export default LocalizedCard;

--- a/apps/docs/components/LocalizedLink/index.spec.tsx
+++ b/apps/docs/components/LocalizedLink/index.spec.tsx
@@ -8,12 +8,6 @@ vi.mock("next/navigation", () => ({
 }));
 
 describe("<LocalizedLink>", () => {
-  it("renders children without href", () => {
-    (useParams as Mock).mockReturnValue({ locale: "en" });
-    const { getByText } = render(<LocalizedLink>Test</LocalizedLink>);
-    expect(getByText("Test")).toBeInTheDocument();
-  });
-
   it("renders with href and locale", () => {
     (useParams as Mock).mockReturnValue({ locale: "en" });
     const { getByText } = render(

--- a/apps/docs/components/LocalizedLink/index.tsx
+++ b/apps/docs/components/LocalizedLink/index.tsx
@@ -10,7 +10,7 @@ interface Props {
   // The children to render inside the link
   children: ReactNode;
   // The href can be a string or an object, similar to Next.js Link
-  href?: string;
+  href: string;
   // The target attribute for the link, defaulting to "_blank"
   target?: ComponentProps<typeof Link>["target"];
 }
@@ -26,11 +26,6 @@ interface Props {
 const LocalizedLink: FC<Props> = ({ children, href, target = "_blank" }) => {
   // Use Next.js router to get the current locale from the URL parameters
   const { locale } = useParams<LocaleRouteParams>();
-
-  // If no href is provided, we simply render the children without a link
-  if (!href) {
-    return <>{children}</>;
-  }
 
   // If the href is a string, we can safely append the locale
   const localizedHref = getLocalizedHref(locale, href);

--- a/apps/docs/components/LocalizedLink/index.tsx
+++ b/apps/docs/components/LocalizedLink/index.tsx
@@ -1,37 +1,10 @@
 "use client";
 
-import type { FC, ReactNode, ComponentProps } from "react";
+import type { ComponentProps, FC, ReactNode } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import type { LocaleRouteParams } from "../../app/[locale]/layout";
-
-/**
- * getLocalizedHref is a utility function that takes a locale and an href
- *
- * @param locale
- * @param href
- */
-function getLocalizedHref(
-  locale: LocaleRouteParams["locale"],
-  href?: Props["href"],
-) {
-  // locale root path is the base path for the locale
-  const localeRootPath = `/${locale}`;
-
-  // if no href is provided, we return the locale root path
-  if (!href) return localeRootPath;
-
-  // if href is an absolute path, we return it as is
-  if (href.startsWith("http://") || href.startsWith("https://")) {
-    return href;
-  }
-
-  // If href is already a full path, we return it as is
-  if (href.startsWith("/")) return `${localeRootPath}${href}`;
-
-  // If href is not a full path, we prepend the locale root path
-  return `${localeRootPath}/${href}`;
-}
+import { getLocalizedHref } from "../../utils/getLocalizedHref";
 
 interface Props {
   // The children to render inside the link

--- a/apps/docs/components/LocalizedLink/index.tsx
+++ b/apps/docs/components/LocalizedLink/index.tsx
@@ -2,9 +2,7 @@
 
 import type { ComponentProps, FC, ReactNode } from "react";
 import Link from "next/link";
-import { useParams } from "next/navigation";
-import type { LocaleRouteParams } from "../../app/[locale]/layout";
-import { getLocalizedHref } from "../../utils/getLocalizedHref";
+import useLocalizedHref from "../../hooks/useLocalizedHref";
 
 interface Props {
   // The children to render inside the link
@@ -24,11 +22,8 @@ interface Props {
  * @param target
  */
 const LocalizedLink: FC<Props> = ({ children, href, target = "_blank" }) => {
-  // Use Next.js router to get the current locale from the URL parameters
-  const { locale } = useParams<LocaleRouteParams>();
-
-  // If the href is a string, we can safely append the locale
-  const localizedHref = getLocalizedHref(locale, href);
+  // Use the custom hook to get the localized href based on the current locale
+  const localizedHref = useLocalizedHref(href);
 
   return (
     <Link

--- a/apps/docs/hooks/useLocalizedHref/index.ts
+++ b/apps/docs/hooks/useLocalizedHref/index.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import type { LocaleRouteParams } from "../../app/[locale]/layout";
+import { getLocalizedHref } from "../../utils/getLocalizedHref";
+
+/**
+ * useLocalizedHref is a custom hook that takes an href with automatically prepended locale.
+ *
+ * @param href
+ */
+const useLocalizedHref = (href: string) => {
+  // Use Next.js router to get the current locale from the URL parameters
+  const { locale } = useParams<LocaleRouteParams>();
+
+  // If the href is a string, we can safely append the locale
+  const localizedHref = getLocalizedHref(locale, href);
+
+  // Return the localized href
+  return localizedHref;
+};
+export default useLocalizedHref;

--- a/apps/docs/utils/getLocalizedHref/index.ts
+++ b/apps/docs/utils/getLocalizedHref/index.ts
@@ -1,0 +1,29 @@
+import type { LocaleRouteParams } from "../../app/[locale]/layout";
+
+/**
+ * getLocalizedHref is a utility function that takes a locale and an href
+ *
+ * @param locale
+ * @param href
+ */
+export function getLocalizedHref(
+  locale: LocaleRouteParams["locale"],
+  href?: string,
+) {
+  // locale root path is the base path for the locale
+  const localeRootPath = `/${locale}`;
+
+  // if no href is provided, we return the locale root path
+  if (!href) return localeRootPath;
+
+  // if href is an absolute path, we return it as is
+  if (href.startsWith("http://") || href.startsWith("https://")) {
+    return href;
+  }
+
+  // If href is already a full path, we return it as is
+  if (href.startsWith("/")) return `${localeRootPath}${href}`;
+
+  // If href is not a full path, we prepend the locale root path
+  return `${localeRootPath}/${href}`;
+}

--- a/apps/docs/utils/getLocalizedHref/index.ts
+++ b/apps/docs/utils/getLocalizedHref/index.ts
@@ -8,13 +8,10 @@ import type { LocaleRouteParams } from "../../app/[locale]/layout";
  */
 export function getLocalizedHref(
   locale: LocaleRouteParams["locale"],
-  href?: string,
+  href: string,
 ) {
   // locale root path is the base path for the locale
   const localeRootPath = `/${locale}`;
-
-  // if no href is provided, we return the locale root path
-  if (!href) return localeRootPath;
 
   // if href is an absolute path, we return it as is
   if (href.startsWith("http://") || href.startsWith("https://")) {


### PR DESCRIPTION
This pull request refactors and improves the localization logic for links in the documentation app. It introduces a new reusable hook, utility function, and component to handle localized URLs more efficiently, while removing redundant code. The most important changes are grouped below by theme.

### New Components and Hooks for Localization

* Added a `LocalizedCard` component that wraps Nextra's `Card` component and automatically prepends the current locale to the `href` using the new `useLocalizedHref` hook (`apps/docs/components/LocalizedCard/index.tsx`).
* Introduced a `useLocalizedHref` custom hook to generate localized URLs dynamically based on the current locale (`apps/docs/hooks/useLocalizedHref/index.ts`).

### Utility Function for Localized URLs

* Created a `getLocalizedHref` utility function to centralize the logic for generating localized URLs, which is now reused across components (`apps/docs/utils/getLocalizedHref/index.ts`).

### Refactoring of `LocalizedLink`

* Refactored the `LocalizedLink` component to use the new `useLocalizedHref` hook instead of handling localization logic directly. Removed the now-redundant `getLocalizedHref` function from this file (`apps/docs/components/LocalizedLink/index.tsx`). [[1]](diffhunk://#diff-9bba1cb4f2eb06260a8b27bbcc8a908b5fd81e498fe37431692191ced918068aL3-R11) [[2]](diffhunk://#diff-9bba1cb4f2eb06260a8b27bbcc8a908b5fd81e498fe37431692191ced918068aL54-R26)

### Test Updates

* Removed an obsolete test case for `LocalizedLink` that handled rendering without an `href`, as this case is no longer applicable after the refactor (`apps/docs/components/LocalizedLink/index.spec.tsx`).