### PR TITLE
`docs` 앱에 `<CodeRepositoryLink>` 컴포넌트 추가 및 적용

### DIFF
--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -81,7 +81,8 @@ jobs:
 
       - name: Generate .env file for docs
         run: |
-          echo "GISCUS_REPO=${{ github.repository }}" > apps/docs/.env.local
+          echo "GITHUB_REPOSITORY=${{ github.repository }}" > apps/docs/.env.local
+          echo "GISCUS_REPO=${{ github.repository }}" >> apps/docs/.env.local
           echo "GISCUS_REPO_ID=${{ secrets.GISCUS_REPO_ID }}" >> apps/docs/.env.local
           echo "GISCUS_DISCUSSION_CATEGORY=${{ vars.GISCUS_DISCUSSION_CATEGORY }}" >> apps/docs/.env.local
           echo "GISCUS_DISCUSSION_CATEGORY_ID=${{ secrets.GISCUS_DISCUSSION_CATEGORY_ID }}" >> apps/docs/.env.local

--- a/apps/docs/components/CodeRepositoryLink/index.spec.tsx
+++ b/apps/docs/components/CodeRepositoryLink/index.spec.tsx
@@ -1,0 +1,42 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { REPOSITORY_CODE_URL } from "../../configs/urls";
+import CodeRepositoryLink from ".";
+
+vi.mock("next/navigation", () => ({
+  useParams: vi.fn(),
+}));
+
+describe("<CodeRepositoryLink>", () => {
+  it("renders with correct href and target", () => {
+    const { getByText } = render(
+      <CodeRepositoryLink href="/path/to/code">View Code</CodeRepositoryLink>,
+    );
+    expect(getByText("View Code").closest("a")).toHaveAttribute(
+      "href",
+      `${REPOSITORY_CODE_URL}${"/path/to/code"}`,
+    );
+  });
+
+  it("uses default target", () => {
+    const { getByText } = render(
+      <CodeRepositoryLink href="/path/to/code">View Code</CodeRepositoryLink>,
+    );
+    expect(getByText("View Code").closest("a")).toHaveAttribute(
+      "target",
+      "_blank",
+    );
+  });
+
+  it("uses custom target", () => {
+    const { getByText } = render(
+      <CodeRepositoryLink href="/path/to/code" target="_self">
+        View Code
+      </CodeRepositoryLink>,
+    );
+    expect(getByText("View Code").closest("a")).toHaveAttribute(
+      "target",
+      "_self",
+    );
+  });
+});

--- a/apps/docs/components/CodeRepositoryLink/index.spec.tsx
+++ b/apps/docs/components/CodeRepositoryLink/index.spec.tsx
@@ -1,11 +1,7 @@
 import { render } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { REPOSITORY_CODE_URL } from "../../configs/urls";
 import CodeRepositoryLink from ".";
-
-vi.mock("next/navigation", () => ({
-  useParams: vi.fn(),
-}));
 
 describe("<CodeRepositoryLink>", () => {
   it("renders with correct href and target", () => {

--- a/apps/docs/components/CodeRepositoryLink/index.spec.tsx
+++ b/apps/docs/components/CodeRepositoryLink/index.spec.tsx
@@ -35,4 +35,14 @@ describe("<CodeRepositoryLink>", () => {
       "_self",
     );
   });
+
+  it("rel attribute is set when target is _blank", () => {
+    const { getByText } = render(
+      <CodeRepositoryLink href="/path/to/code">View Code</CodeRepositoryLink>,
+    );
+    expect(getByText("View Code").closest("a")).toHaveAttribute(
+      "rel",
+      "noopener noreferrer",
+    );
+  });
 });

--- a/apps/docs/components/CodeRepositoryLink/index.tsx
+++ b/apps/docs/components/CodeRepositoryLink/index.tsx
@@ -1,0 +1,44 @@
+import type { ComponentProps, FC, ReactNode } from "react";
+import Link from "next/link";
+import { Button } from "@repo/react-ui/shadcn-ui";
+import { REPOSITORY_CODE_URL } from "../../configs/urls";
+
+interface Props {
+  // The children to render inside the link
+  children: ReactNode;
+  // The href can be a string or an object, similar to Next.js Link
+  href: string;
+  // The target attribute for the link, defaulting to "_blank"
+  target?: ComponentProps<typeof Link>["target"];
+}
+
+/**
+ * CodeRepositoryLink is a component that wraps Next.js Link
+ * with a specific code repository URL
+ *
+ * @param children
+ * @param href
+ * @param target
+ */
+const CodeRepositoryLink: FC<Props> = ({
+  children,
+  href,
+  target = "_blank",
+}) => {
+  // Construct the full URL for the code repository link
+  const codeUrl = `${REPOSITORY_CODE_URL}${href}`;
+
+  return (
+    <Button asChild variant="link" className="px-0">
+      <Link
+        href={codeUrl}
+        target={target}
+        // for preventing reverse tapnabbing vulnerability
+        rel={target === "_blank" ? "noopener noreferrer" : undefined}
+      >
+        {children}
+      </Link>
+    </Button>
+  );
+};
+export default CodeRepositoryLink;

--- a/apps/docs/components/LocalizedLink/index.spec.tsx
+++ b/apps/docs/components/LocalizedLink/index.spec.tsx
@@ -42,4 +42,14 @@ describe("<LocalizedLink>", () => {
       "_self",
     );
   });
+
+  it("rel attribute is set when target is _blank", () => {
+    const { getByText } = render(
+      <LocalizedLink href="/about">About Us</LocalizedLink>,
+    );
+    expect(getByText("About Us").closest("a")).toHaveAttribute(
+      "rel",
+      "noopener noreferrer",
+    );
+  });
 });

--- a/apps/docs/configs/urls.ts
+++ b/apps/docs/configs/urls.ts
@@ -1,0 +1,4 @@
+/**
+ * GitHub repository URL for the documentation.
+ */
+export const REPOSITORY_CODE_URL = `https://github.com/${process.env.GITHUB_REPOSITORY}/tree/main`;

--- a/apps/docs/content/en/documentation/how-to-write.mdx
+++ b/apps/docs/content/en/documentation/how-to-write.mdx
@@ -75,7 +75,7 @@ import CodeRepositoryLink from "../../../components/CodeRepositoryLink";
 <a
   target="_blank"
   rel="noopener noreferrer"
-  href="https://github.com/iamhoonse-dev/turborepo-template/tree/main/packages/browser-utils/src/dom"
+  href="https://github.com/iamhoonse-dev/turborepo-template/tree/main/packages/react-utils/src/hooks"
 >
   <!-- Note: The part iamhoonse-dev/turborepo-template will be replaced with the value of the environment variable GITHUB_REPOSITORY. -->
   react-utils/hooks

--- a/apps/docs/content/en/documentation/how-to-write.mdx
+++ b/apps/docs/content/en/documentation/how-to-write.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../components/CodeRepositoryLink";
 
 # ✏️ How to Write
 
@@ -51,6 +52,44 @@ import LocalizedLink from "../../../components/LocalizedLink";
   Korean Document Sample
 </a>
 ```
+
+### Using the `<CodeRepositoryLink>` Component
+
+This documentation application provides the `<Callout>` component.
+By using this component, you can easily create code repository links.
+
+For example, if you write the code as follows,
+the link will be automatically converted to the corresponding path in the GitHub repository:
+
+```mdx filename="code-repository-link-usage.mdx"
+import CodeRepositoryLink from "../../../components/CodeRepositoryLink";
+
+<CodeRepositoryLink
+  href="/packages/react-utils/src/hooks"
+>
+  react-utils/hooks
+</CodeRepositoryLink>
+```
+
+```html filename="rendered-code-repository-link.html"
+<a
+  target="_blank"
+  rel="noopener noreferrer"
+  href="https://github.com/iamhoonse-dev/turborepo-template/tree/main/packages/browser-utils/src/dom"
+>
+  <!-- Note: The part iamhoonse-dev/turborepo-template will be replaced with the value of the environment variable GITHUB_REPOSITORY. -->
+  react-utils/hooks
+</a>
+```
+
+<Callout type="info">
+  The automatically generated path depends on the environment variable `GITHUB_REPOSITORY`. For example,
+  - If the environment variable `GITHUB_REPOSITORY` is set to `your-name/repo-name`, and
+  - The path specified in the component's `href` property is `/packages/react-utils/src/hooks`,
+
+  The final generated link will be `https://github.com/your-name/repo-name/tree/main/packages/react-utils/src/hooks`.
+  For more details, refer to the <CodeRepositoryLink href="/apps/docs/components/CodeRepositoryLink">`CodeRepositoryLink` component code</CodeRepositoryLink>.
+</Callout>
 
 ## 🖼️ Image Attachment Guide
 

--- a/apps/docs/content/en/packages/default-packages/browser-utils.mdx
+++ b/apps/docs/content/en/packages/default-packages/browser-utils.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # 🌐 Browser Utils
 
@@ -33,9 +34,9 @@ It is designed with the following purposes:
 
 As examples of features that work in the browser environment, the `browser-utils` package includes the following sample features:
 
-- **[DOM](src/dom)**: Provides utility functions for manipulating the browser DOM.
-- **[MSW](src/msw)**: Provides utilities related to Mock Service Worker.
-- **[String](src/string)**: Provides utility functions for string processing.
+- <CodeRepositoryLink href="/packages/browser-utils/src/dom">**DOM**</CodeRepositoryLink>: Provides utility functions for manipulating the browser DOM.
+- <CodeRepositoryLink href="/packages/browser-utils/src/msw">**MSW**</CodeRepositoryLink>: Provides utilities related to Mock Service Worker.
+- <CodeRepositoryLink href="/packages/browser-utils/src/string">**String**</CodeRepositoryLink>: Provides utility functions for string processing.
 
 ## 🛠️ Build Method & Main Settings
 

--- a/apps/docs/content/en/packages/default-packages/eslint-plugin-sample.mdx
+++ b/apps/docs/content/en/packages/default-packages/eslint-plugin-sample.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # 🛡️ eslint-plugin-sample
 
@@ -29,9 +30,9 @@ It is designed with the following purposes:
 
 ## 📦 Provided Features
 
-- **[Rules](./lib/rules)**: Folder for defining ESLint rules, each rule is managed in a separate file.
-- **[docs](./docs/rules)**: Folder for writing documentation for each rule, including usage and examples.
-- **[tests](./tests/lib/rules)**: Folder for writing test cases for rules to verify correct operation.
+- <CodeRepositoryLink href="/packages/eslint-plugin-sample/lib/rules">**Rules**</CodeRepositoryLink>: Folder for defining ESLint rules, each rule is managed in a separate file.
+- <CodeRepositoryLink href="/packages/eslint-plugin-sample/docs/rules">**docs**</CodeRepositoryLink>: Folder for writing documentation for each rule, including usage and examples.
+- <CodeRepositoryLink href="/packages/eslint-plugin-sample/tests/lib/rules">**tests**</CodeRepositoryLink>: Folder for writing test cases for rules to verify correct operation.
 
 ## ✏️ How was this package created?
 

--- a/apps/docs/content/en/packages/default-packages/http-clients.mdx
+++ b/apps/docs/content/en/packages/default-packages/http-clients.mdx
@@ -1,3 +1,5 @@
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
+
 # 🌐 HTTP Clients
 
 ## 📖 Overview
@@ -15,9 +17,9 @@ This package is designed with the following main purposes:
 
 ## 📦 Provided Features
 
-- **[Instances](src/instances)**: Provides HTTP client instances such as `self` and `iamhoonse.dev`.
-- **[Mocks](src/mocks)**: Provides request handlers related to `self` and `iamhoonse.dev` for use with MSW (Mock Service Worker).
-- **[Types](src/types)**: Defines types related to HTTP requests and responses.
+- <CodeRepositoryLink href="/packages/http-clients/src/instances">**Instances**</CodeRepositoryLink>: Provides HTTP client instances such as `self` and `iamhoonse.dev`.
+- <CodeRepositoryLink href="/packages/http-clients/src/mocks">**Mocks**</CodeRepositoryLink>: Provides request handlers related to `self` and `iamhoonse.dev` for use with MSW (Mock Service Worker).
+- <CodeRepositoryLink href="/packages/http-clients/src/types">**Types**</CodeRepositoryLink>: Defines types related to HTTP requests and responses.
 
 ## 🛠️ Build Method & Main Settings
 

--- a/apps/docs/content/en/packages/default-packages/node-utils.mdx
+++ b/apps/docs/content/en/packages/default-packages/node-utils.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # 🌱️ Node Utils
 
@@ -31,9 +32,9 @@ It is designed with the following purposes:
 
 ## 📦 Provided Features
 
-- **[fs](./src/fs)**: Provides utility functions related to the file system.
-- **[msw](./src/msw)**: Provides MSW-related utility functions for API mocking.
-- **[misc](./src/misc)**: Provides other useful utility functions.
+- <CodeRepositoryLink href="/packages/node-utils/src/fs">**fs**</CodeRepositoryLink>: Provides utility functions related to the file system.
+- <CodeRepositoryLink href="/packages/node-utils/src/msw">**msw**</CodeRepositoryLink>: Provides MSW-related utility functions for API mocking.
+- <CodeRepositoryLink href="/packages/node-utils/src/misc">**misc**</CodeRepositoryLink>: Provides other useful utility functions.
 
 ## 🛠️ Build Method & Main Settings
 

--- a/apps/docs/content/en/packages/default-packages/react-ui.mdx
+++ b/apps/docs/content/en/packages/default-packages/react-ui.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # 🖼️ React UI
 
@@ -34,11 +35,11 @@ It is designed with the following purposes:
 
 ## 📦 Provided Features
 
-- **[ShadCN UI](./shadcn-ui)**: Provides modules related to ShadCN UI.
-- **[Utils](./utils)**: Provides a collection of UI-related utility functions for use in React applications.
-- **[Components](./components)**: Provides various React UI components.
-- **[Constants](./constants)**: Provides style-related constants such as breakpoints for responsive design.
-- **[Base CSS](./base.css)**: Provides the base style file.
+- <CodeRepositoryLink href="/packages/react-ui/src/base/shadcn-ui">**ShadCN UI**</CodeRepositoryLink>: Provides modules related to ShadCN UI.
+- <CodeRepositoryLink href="/packages/react-ui/src/lib/utils.ts">**Utils**</CodeRepositoryLink>: Offers a collection of UI utility functions for use in React applications.
+- <CodeRepositoryLink href="/packages/react-ui/src/components">**Components**</CodeRepositoryLink>: Provides various React UI components.
+- <CodeRepositoryLink href="/packages/react-ui/src/constants">**Constants**</CodeRepositoryLink>: Provides style-related constants such as breakpoints for responsive design.
+- <CodeRepositoryLink href="/packages/react-ui/src/styles">**Base CSS**</CodeRepositoryLink>: Provides base style files.
 
 ## 🛠️ Build Method & Main Settings
 

--- a/apps/docs/content/en/packages/default-packages/react-utils.mdx
+++ b/apps/docs/content/en/packages/default-packages/react-utils.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # ⚛️ React Utils
 
@@ -32,9 +33,9 @@ It is designed with the following purposes:
 
 ## 📦 Provided Features
 
-- **[Hooks](./hooks)**: Provides a collection of useful custom hooks for use in React applications.
-- **[HoCs](./hocs)**: Provides various higher-order components to assist React component development.
-- **[Providers](./providers)**: Provides utilities that utilize React Context.
+- <CodeRepositoryLink href="/packages/react-utils/src/hooks">**Hooks**</CodeRepositoryLink>: Provides a collection of useful custom hooks for use in React applications.
+- <CodeRepositoryLink href="/packages/react-utils/src/hocs">**HoCs**</CodeRepositoryLink>: Provides various higher-order components to assist React component development.
+- <CodeRepositoryLink href="/packages/react-utils/src/providers">**Providers**</CodeRepositoryLink>: Provides utilities that utilize React Context.
 
 ## 🛠️ Build Method & Main Settings
 

--- a/apps/docs/content/ja/documentation/how-to-write.mdx
+++ b/apps/docs/content/ja/documentation/how-to-write.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../components/CodeRepositoryLink";
 
 # ✏️ 書き方
 
@@ -51,6 +52,44 @@ import LocalizedLink from "../../../components/LocalizedLink";
   日本語ドキュメントサンプル
 </a>
 ```
+
+### `<CodeRepositoryLink>` コンポーネントの使い方
+
+このドキュメントアプリケーションでは `<Callout>` コンポーネントを提供しています。
+このコンポーネントを使用すると、コードリポジトリへのリンクを簡単に作成できます。
+
+例えば、次のようにコードを書くと、
+リンクはGitHubリポジトリの該当パスに自動的に変換されます：
+
+```mdx filename="code-repository-link-usage.mdx"
+import CodeRepositoryLink from "../../../components/CodeRepositoryLink";
+
+<CodeRepositoryLink
+  href="/packages/react-utils/src/hooks"
+>
+  react-utils/hooks
+</CodeRepositoryLink>
+```
+
+```html filename="rendered-code-repository-link.html"
+<a
+  target="_blank"
+  rel="noopener noreferrer"
+  href="https://github.com/iamhoonse-dev/turborepo-template/tree/main/packages/browser-utils/src/dom"
+>
+  <!-- 注: iamhoonse-dev/turborepo-template の部分は環境変数 GITHUB_REPOSITORY の値に置き換わります。 -->
+  react-utils/hooks
+</a>
+```
+
+<Callout type="info">
+  自動生成されるパスは環境変数 `GITHUB_REPOSITORY` によって異なります。例えば、
+  - 環境変数 `GITHUB_REPOSITORY` が `your-name/repo-name` に設定されていて、
+  - コンポーネントの `href` プロパティに指定されたパスが `/packages/react-utils/src/hooks` の場合、
+
+  最終的に生成されるリンクは `https://github.com/your-name/repo-name/tree/main/packages/react-utils/src/hooks` になります。
+  詳細については <CodeRepositoryLink href="/apps/docs/components/CodeRepositoryLink">`CodeRepositoryLink` コンポーネントのコード</CodeRepositoryLink> を参照してください。
+</Callout>
 
 ## 🖼️ 画像添付ガイド
 

--- a/apps/docs/content/ja/documentation/how-to-write.mdx
+++ b/apps/docs/content/ja/documentation/how-to-write.mdx
@@ -75,7 +75,7 @@ import CodeRepositoryLink from "../../../components/CodeRepositoryLink";
 <a
   target="_blank"
   rel="noopener noreferrer"
-  href="https://github.com/iamhoonse-dev/turborepo-template/tree/main/packages/browser-utils/src/dom"
+  href="https://github.com/iamhoonse-dev/turborepo-template/tree/main/packages/react-utils/src/hooks"
 >
   <!-- 注: iamhoonse-dev/turborepo-template の部分は環境変数 GITHUB_REPOSITORY の値に置き換わります。 -->
   react-utils/hooks

--- a/apps/docs/content/ja/packages/default-packages/browser-utils.mdx
+++ b/apps/docs/content/ja/packages/default-packages/browser-utils.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # 🌐 ブラウザユーティリティ
 
@@ -33,9 +34,9 @@ import { Callout } from "nextra/components";
 
 `browser-utils` パッケージは、ブラウザ環境で動作する機能の例として、以下のサンプル機能を含みます:
 
-- **[DOM](src/dom)**: ブラウザDOM操作用のユーティリティ関数を提供します。
-- **[MSW](src/msw)**: Mock Service Worker関連のユーティリティを提供します。
-- **[String](src/string)**: 文字列処理関連のユーティリティ関数を提供します。
+- <CodeRepositoryLink href="/packages/browser-utils/src/dom">**DOM**</CodeRepositoryLink>: ブラウザDOM操作用のユーティリティ関数を提供します。
+- <CodeRepositoryLink href="/packages/browser-utils/src/msw">**MSW**</CodeRepositoryLink>: Mock Service Worker関連のユーティリティを提供します。
+- <CodeRepositoryLink href="/packages/browser-utils/src/string">**String**</CodeRepositoryLink>: 文字列処理関連のユーティリティ関数を提供します。
 
 ## 🛠️ ビルド方式および主な設定
 

--- a/apps/docs/content/ja/packages/default-packages/eslint-plugin-sample.mdx
+++ b/apps/docs/content/ja/packages/default-packages/eslint-plugin-sample.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # 🛡️ eslint-plugin-sample
 
@@ -29,9 +30,9 @@ Turborepo内でESLintプラグインを自作する際、このパッケージ�
 
 ## 📦 提供機能
 
-- **[Rules](./lib/rules)**: ESLintルールを定義するフォルダで、各ルールは個別ファイルで管理されます。
-- **[docs](./docs/rules)**: 各ルールのドキュメントを作成するフォルダで、ルールの使い方や例を含みます。
-- **[tests](./tests/lib/rules)**: ルールのテストケースを作成するフォルダで、ルールが正しく動作するか検証します。
+- <CodeRepositoryLink href="/packages/eslint-plugin-sample/lib/rules">**Rules**</CodeRepositoryLink>: ESLintルールを定義するフォルダで、各ルールは個別ファイルで管理されます。
+- <CodeRepositoryLink href="/packages/eslint-plugin-sample/docs/rules">**docs**</CodeRepositoryLink>: 各ルールのドキュメントを作成するフォルダで、ルールの使い方や例を含みます。
+- <CodeRepositoryLink href="/packages/eslint-plugin-sample/tests/lib/rules">**tests**</CodeRepositoryLink>: ルールのテストケースを作成するフォルダで、ルールが正しく動作するか検証します。
 
 ## ✏️ このパッケージはどのように作成されましたか？
 

--- a/apps/docs/content/ja/packages/default-packages/http-clients.mdx
+++ b/apps/docs/content/ja/packages/default-packages/http-clients.mdx
@@ -1,3 +1,5 @@
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
+
 # 🌐 HTTPクライアント
 
 ## 📖 概要
@@ -15,9 +17,9 @@
 
 ## 📦 提供機能
 
-- **[Instances](src/instances)**: `self` および `iamhoonse.dev` などのHTTPクライアントインスタンスを提供します。
-- **[Mocks](src/mocks)**: `self` および `iamhoonse.dev` に関連するリクエストハンドラをMSW（Mock Service Worker）と共に提供します。
-- **[Types](src/types)**: HTTPリクエストやレスポンスに関連する型を定義します。
+- <CodeRepositoryLink href="/packages/http-clients/src/instances">**Instances**</CodeRepositoryLink>: `self` および `iamhoonse.dev` などのHTTPクライアントインスタンスを提供します。
+- <CodeRepositoryLink href="/packages/http-clients/src/mocks">**Mocks**</CodeRepositoryLink>: `self` および `iamhoonse.dev` に関連するリクエストハンドラをMSW（Mock Service Worker）と共に提供します。
+- <CodeRepositoryLink href="/packages/http-clients/src/types">**Types**</CodeRepositoryLink>: HTTPリクエストやレスポンスに関連する型を定義します。
 
 ## 🛠️ ビルド方式および主な設定
 

--- a/apps/docs/content/ja/packages/default-packages/node-utils.mdx
+++ b/apps/docs/content/ja/packages/default-packages/node-utils.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # 🌱️ Nodeユーティリティ
 
@@ -31,9 +32,9 @@ Node.js環境で動作する新しいパッケージを追加したい場合、�
 
 ## 📦 提供機能
 
-- **[fs](./src/fs)**: ファイルシステム関連のユーティリティ関数を提供します。
-- **[msw](./src/msw)**: APIモック用のMSW関連ユーティリティ関数を提供します。
-- **[misc](./src/misc)**: その他便利なユーティリティ関数を提供します。
+- <CodeRepositoryLink href="/packages/node-utils/src/fs">**fs**</CodeRepositoryLink>: ファイルシステム関連のユーティリティ関数を提供します。
+- <CodeRepositoryLink href="/packages/node-utils/src/msw">**msw**</CodeRepositoryLink>: APIモック用のMSW関連ユーティリティ関数を提供します。
+- <CodeRepositoryLink href="/packages/node-utils/src/misc">**misc**</CodeRepositoryLink>: その他便利なユーティリティ関数を提供します。
 
 ## 🛠️ ビルド方式および主な設定
 

--- a/apps/docs/content/ja/packages/default-packages/react-ui.mdx
+++ b/apps/docs/content/ja/packages/default-packages/react-ui.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # 🖼️ React UI
 
@@ -34,11 +35,11 @@ Reactコンポーネント形式で利用可能なUIパッケージを新たに�
 
 ## 📦 提供機能
 
-- **[ShadCN UI](./shadcn-ui)**: ShadCN UI関連モジュールを提供します。
-- **[Utils](./utils)**: Reactアプリケーションで使えるUI関連ユーティリティ関数集を提供します。
-- **[Components](./components)**: 様々なReact UIコンポーネントを提供します。
-- **[Constants](./constants)**: レスポンシブデザイン用のBreakpointsなどスタイル関連定数を提供します。
-- **[Base CSS](./base.css)**: 基本スタイルファイルを提供します。
+- <CodeRepositoryLink href="/packages/react-ui/src/base/shadcn-ui">**ShadCN UI**</CodeRepositoryLink>: ShadCN UI関連モジュールを提供します。
+- <CodeRepositoryLink href="/packages/react-ui/src/lib/utils.ts">**Utils**</CodeRepositoryLink>: Reactアプリケーションで利用できるUI関連ユーティリティ関数集を提供します。
+- <CodeRepositoryLink href="/packages/react-ui/src/components">**Components**</CodeRepositoryLink>: 様々なReact UIコンポーネントを提供します。
+- <CodeRepositoryLink href="/packages/react-ui/src/constants">**Constants**</CodeRepositoryLink>: レスポンシブデザイン用のBreakpointsなど、スタイル関連の定数を提供します。
+- <CodeRepositoryLink href="/packages/react-ui/src/styles">**Base CSS**</CodeRepositoryLink>: 基本スタイルファイルを提供します。
 
 ## 🛠️ ビルド方式および主な設定
 

--- a/apps/docs/content/ja/packages/default-packages/react-utils.mdx
+++ b/apps/docs/content/ja/packages/default-packages/react-utils.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # ⚛️ Reactユーティリティ
 
@@ -32,9 +33,9 @@ Reactユーティリティパッケージを新たに追加したい場合、こ
 
 ## 📦 提供機能
 
-- **[Hooks](./hooks)**: Reactアプリケーションで使える便利なカスタムフック集を提供します。
-- **[HoCs](./hocs)**: Reactコンポーネント開発を助ける様々な高階コンポーネントを提供します。
-- **[Providers](./providers)**: React Contextを活用するユーティリティを提供します。
+- <CodeRepositoryLink href="/packages/react-utils/src/hooks">**Hooks**</CodeRepositoryLink>: Reactアプリケーションで使える便利なカスタムフック集を提供します。
+- <CodeRepositoryLink href="/packages/react-utils/src/hocs">**HoCs**</CodeRepositoryLink>: Reactコンポーネント開発を助ける様々な高階コンポーネントを提供します。
+- <CodeRepositoryLink href="/packages/react-utils/src/providers">**Providers**</CodeRepositoryLink>: React Contextを活用するユーティリティを提供します。
 
 ## 🛠️ ビルド方式および主な設定
 

--- a/apps/docs/content/ko/documentation/how-to-write.mdx
+++ b/apps/docs/content/ko/documentation/how-to-write.mdx
@@ -75,7 +75,7 @@ import CodeRepositoryLink from "../../../components/CodeRepositoryLink";
 <a
   target="_blank"
   rel="noopener noreferrer"
-  href="https://github.com/iamhoonse-dev/turborepo-template/tree/main/packages/browser-utils/src/dom"
+  href="https://github.com/iamhoonse-dev/turborepo-template/tree/main/packages/react-utils/src/hooks"
 >
   <!-- Note: iamhoonse-dev/turborepo-template 부분은 환경 변수 GITHUB_REPOSITORY 값으로 변경됩니다. -->
   react-utils/hooks

--- a/apps/docs/content/ko/documentation/how-to-write.mdx
+++ b/apps/docs/content/ko/documentation/how-to-write.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../components/CodeRepositoryLink";
 
 # ✏️ 작성 방법
 
@@ -51,6 +52,44 @@ import LocalizedLink from "../../../components/LocalizedLink";
   한국어 문서 샘플
 </a>
 ```
+
+### `<CodeRepositoryLink>` 컴포넌트 사용하기
+
+이 문서화 어플리케이션에서는 `<Callout>` 컴포넌트를 제공합니다.
+이 컴포넌트를 사용하면 코드 저장소 링크를 쉽게 작성할 수 있습니다.
+
+예를 들어, 다음과 같이 코드를 작성할 경우,
+링크는 GitHub 저장소의 해당 경로로 자동 변환됩니다:
+
+```mdx filename="code-repository-link-usage.mdx"
+import CodeRepositoryLink from "../../../components/CodeRepositoryLink";
+
+<CodeRepositoryLink
+  href="/packages/react-utils/src/hooks"
+>
+  react-utils/hooks
+</CodeRepositoryLink>
+```
+
+```html filename="rendered-code-repository-link.html"
+<a
+  target="_blank"
+  rel="noopener noreferrer"
+  href="https://github.com/iamhoonse-dev/turborepo-template/tree/main/packages/browser-utils/src/dom"
+>
+  <!-- Note: iamhoonse-dev/turborepo-template 부분은 환경 변수 GITHUB_REPOSITORY 값으로 변경됩니다. -->
+  react-utils/hooks
+</a>
+```
+
+<Callout type="info">
+  자동으로 생성되는 경로는 환경 변수 `GITHUB_REPOSITORY`에 따라 달라집니다. 예를 들어,
+  - 환경 변수 `GITHUB_REPOSITORY`가 `your-name/repo-name`로 설정되어 있고,
+  - 컴포넌트의 `href` 프로퍼티에 지정된 경로가 `/packages/react-utils/src/hooks` 라면,
+
+  최종적으로 생성되는 링크는 `https://github.com/your-name/repo-name/tree/main/packages/react-utils/src/hooks`로 생성됩니다.
+  관련하여 보다 자세한 내용은 <CodeRepositoryLink href="/apps/docs/components/CodeRepositoryLink">`CodeRepositoryLink` 컴포넌트 코드</CodeRepositoryLink>를 참고하세요.
+</Callout>
 
 ## 🖼️ 이미지 첨부 가이드
 

--- a/apps/docs/content/ko/packages/default-packages/browser-utils.mdx
+++ b/apps/docs/content/ko/packages/default-packages/browser-utils.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # 🌐 Browser Utils
 
@@ -33,9 +34,9 @@ import { Callout } from "nextra/components";
 
 `browser-utils` 패키지는 브라우저 환경에서 동작하는 기능들의 예시로서, 다음과 같은 샘플 기능들을 포함하고 있어요:
 
-- **[DOM](src/dom)**: 브라우저 DOM 조작을 위한 유틸리티 함수 제공해요.
-- **[MSW](src/msw)**: Mock Service Worker와 관련된 유틸리티를 제공해요.
-- **[String](src/string)**: 문자열 처리와 관련된 유틸리티 함수 제공해요.
+- <CodeRepositoryLink href="/packages/browser-utils/src/dom">**DOM**</CodeRepositoryLink>: 브라우저 DOM 조작을 위한 유틸리티 함수 제공해요.
+- <CodeRepositoryLink href="/packages/browser-utils/src/msw">**MSW**</CodeRepositoryLink>: Mock Service Worker와 관련된 유틸리티를 제공해요.
+- <CodeRepositoryLink href="/packages/browser-utils/src/string">**String**</CodeRepositoryLink>: 문자열 처리와 관련된 유틸리티 함수 제공해요.
 
 ## 🛠️ 빌드 방식 및 주요 설정
 

--- a/apps/docs/content/ko/packages/default-packages/eslint-plugin-sample.mdx
+++ b/apps/docs/content/ko/packages/default-packages/eslint-plugin-sample.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # 🛡️ eslint-plugin-sample
 
@@ -29,9 +30,9 @@ Turborepo 내에서 ESLint 플러그인을 자체적으로 개발할 때, 이 �
 
 ## 📦 제공 기능
 
-- **[Rules](./lib/rules)**: ESLint 규칙을 정의하는 폴더로, 각 규칙은 별도의 파일로 관리됩니다.
-- **[docs](./docs/rules)**: 각 규칙에 대한 문서를 작성하는 폴더로, 규칙의 사용법과 예제를 포함합니다.
-- **[tests](./tests/lib/rules)**: 규칙에 대한 테스트 케이스를 작성하는 폴더로, 규칙이 올바르게 동작하는지 검증합니다.
+- <CodeRepositoryLink href="/packages/eslint-plugin-sample/lib/rules">**Rules**</CodeRepositoryLink>: ESLint 규칙을 정의하는 폴더로, 각 규칙은 별도의 파일로 관리됩니다.
+- <CodeRepositoryLink href="/packages/eslint-plugin-sample/docs/rules">**docs**</CodeRepositoryLink>: 각 규칙에 대한 문서를 작성하는 폴더로, 규칙의 사용법과 예제를 포함합니다.
+- <CodeRepositoryLink href="/packages/eslint-plugin-sample/tests/lib/rules">**tests**</CodeRepositoryLink>: 규칙에 대한 테스트 케이스를 작성하는 폴더로, 규칙이 올바르게 동작하는지 검증합니다.
 
 ## ✏️ 이 패키지는 어떻게 작성되었나요?
 

--- a/apps/docs/content/ko/packages/default-packages/http-clients.mdx
+++ b/apps/docs/content/ko/packages/default-packages/http-clients.mdx
@@ -1,3 +1,5 @@
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
+
 # 🌐 HTTP Clients
 
 ## 📖 개요
@@ -15,9 +17,9 @@
 
 ## 📦 제공 기능
 
-- **[Instances](src/instances)**: `self` 및 `iamhoonse.dev`와 같은 HTTP 클라이언트 인스턴스를 제공해요.
-- **[Mocks](src/mocks)**: `self` 및 `iamhoonse.dev`와 관련된 요청 핸들러를 MSW(Mock Service Worker)와 함께 사용할 수 있도록 제공해요.
-- **[Types](src/types)**: HTTP 요청 및 응답과 관련된 타입을 정의해요.
+- <CodeRepositoryLink href="/packages/http-clients/src/instances">**Instances**</CodeRepositoryLink>: `self` 및 `iamhoonse.dev`와 같은 HTTP 클라이언트 인스턴스를 제공해요.
+- <CodeRepositoryLink href="/packages/http-clients/src/mocks">**Mocks**</CodeRepositoryLink>: `self` 및 `iamhoonse.dev`와 관련된 요청 핸들러를 MSW(Mock Service Worker)와 함께 사용할 수 있도록 제공해요.
+- <CodeRepositoryLink href="/packages/http-clients/src/types">**Types**</CodeRepositoryLink>: HTTP 요청 및 응답과 관련된 타입을 정의해요.
 
 ## 🛠️ 빌드 방식 및 주요 설정
 

--- a/apps/docs/content/ko/packages/default-packages/node-utils.mdx
+++ b/apps/docs/content/ko/packages/default-packages/node-utils.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # 🌱️ Node Utils
 
@@ -31,9 +32,9 @@ Node.js 환경에서 동작하는 새 패키지를 추가하고 싶을 때, 이 
 
 ## 📦 제공 기능
 
-- **[fs](./src/fs)**: 파일 시스템 관련 유틸리티 함수들을 제공해요.
-- **[msw](./src/msw)**: API 목업을 위한 MSW 관련 유틸리티 함수들을 제공해요.
-- **[misc](./src/misc)**: 기타 유용한 유틸리티 함수들을 제공해요.
+- <CodeRepositoryLink href="/packages/node-utils/src/fs">**fs**</CodeRepositoryLink>: 파일 시스템 관련 유틸리티 함수들을 제공해요.
+- <CodeRepositoryLink href="/packages/node-utils/src/msw">**msw**</CodeRepositoryLink>: API 목업을 위한 MSW 관련 유틸리티 함수들을 제공해요.
+- <CodeRepositoryLink href="/packages/node-utils/src/misc">**misc**</CodeRepositoryLink>: 기타 유용한 유틸리티 함수들을 제공해요.
 
 ## 🛠️ 빌드 방식 및 주요 설정
 

--- a/apps/docs/content/ko/packages/default-packages/react-ui.mdx
+++ b/apps/docs/content/ko/packages/default-packages/react-ui.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # 🖼️ React UI
 
@@ -34,11 +35,11 @@ React 컴포넌트 형태로 사용 가능한 UI 패키지를 새로 추가하�
 
 ## 📦 제공 기능
 
-- **[ShadCN UI](./shadcn-ui)**: ShadCN UI 관련 모듈을 제공해요.
-- **[Utils](./utils)**: React 애플리케이션에서 사용할 수 있는 UI 관련 유틸리티 함수 모음을 제공해요.
-- **[Components](./components)**: 다양한 React UI 컴포넌트를 제공해요.
-- **[Constants](./constants)**: 반응형 디자인을 위한 Breakpoints 등과 같은 스타일 관련 상수들을 제공해요.
-- **[Base CSS](./base.css)**: 기본 스타일 파일을 제공해요.
+- <CodeRepositoryLink href="/packages/react-ui/src/base/shadcn-ui">**ShadCN UI**</CodeRepositoryLink>: ShadCN UI 관련 모듈을 제공해요.
+- <CodeRepositoryLink href="/packages/react-ui/src/lib/utils.ts">**Utils**</CodeRepositoryLink>: React 애플리케이션에서 사용할 수 있는 UI 관련 유틸리티 함수 모음을 제공해요.
+- <CodeRepositoryLink href="/packages/react-ui/src/components">**Components**</CodeRepositoryLink>: 다양한 React UI 컴포넌트를 제공해요.
+- <CodeRepositoryLink href="/packages/react-ui/src/constants">**Constants**</CodeRepositoryLink>: 반응형 디자인을 위한 Breakpoints 등과 같은 스타일 관련 상수들을 제공해요.
+- <CodeRepositoryLink href="/packages/react-ui/src/styles">**Base CSS**</CodeRepositoryLink>: 기본 스타일 파일을 제공해요.
 
 ## 🛠️ 빌드 방식 및 주요 설정
 

--- a/apps/docs/content/ko/packages/default-packages/react-utils.mdx
+++ b/apps/docs/content/ko/packages/default-packages/react-utils.mdx
@@ -1,4 +1,5 @@
 import { Callout } from "nextra/components";
+import CodeRepositoryLink from "../../../../components/CodeRepositoryLink";
 
 # ⚛️ React Utils
 
@@ -32,9 +33,9 @@ React 유틸리티 패키지를 새로 추가하고 싶을 때, 이 패키지를
 
 ## 📦 제공 기능
 
-- **[Hooks](./hooks)**: React 애플리케이션에서 사용할 수 있는 유용한 커스텀 훅 모음을 제공해요.
-- **[HoCs](./hocs)**: React 컴포넌트 개발을 돕는 다양한 고차 컴포넌트들을 제공해요.
-- **[Providers](./providers)**: React Context 를 활용하는 유틸리티를 제공해요.
+- <CodeRepositoryLink href="/packages/react-utils/src/hooks">**Hooks**</CodeRepositoryLink>: React 애플리케이션에서 사용할 수 있는 유용한 커스텀 훅 모음을 제공해요.
+- <CodeRepositoryLink href="/packages/react-utils/src/hocs">**HoCs**</CodeRepositoryLink>: React 컴포넌트 개발을 돕는 다양한 고차 컴포넌트들을 제공해요.
+- <CodeRepositoryLink href="/packages/react-utils/src/providers">**Providers**</CodeRepositoryLink>: React Context 를 활용하는 유틸리티를 제공해요.
 
 ## 🛠️ 빌드 방식 및 주요 설정
 

--- a/apps/docs/env.d.ts
+++ b/apps/docs/env.d.ts
@@ -2,6 +2,8 @@ declare module "process" {
   global {
     namespace NodeJS {
       interface ProcessEnv {
+        // GITHUB_REPOSITORY 는 코드 링크 URL 구성에 사용되는 GitHub 저장소 이름입니다.
+        GITHUB_REPOSITORY: `${string}/${string}`;
         // GITHUB_REPO는 Giscus 에서 사용하는 GitHub 저장소 이름입니다.
         GISCUS_REPO: `${string}/${string}`;
         // GITHUB_REPO_ID는 Giscus 에서 사용하는 GitHub 저장소 ID 입니다.

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*", "!**/*.stories.{tsx,jsx,mdx}"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**", "storybook-static/**", "out/**"],
-      "passThroughEnv": ["GISCUS_REPO", "GISCUS_REPO_ID", "GISCUS_DISCUSSION_CATEGORY", "GISCUS_DISCUSSION_CATEGORY_ID"]
+      "passThroughEnv": ["GITHUB_REPOSITORY", "GISCUS_REPO", "GISCUS_REPO_ID", "GISCUS_DISCUSSION_CATEGORY", "GISCUS_DISCUSSION_CATEGORY_ID"]
     },
     "@repo/react-utils#build": {
       "dependsOn": ["@repo/browser-utils#build"]


### PR DESCRIPTION
This pull request introduces the `CodeRepositoryLink` component, which simplifies the creation of GitHub repository links in the documentation. It also updates multiple documentation files to utilize this new component for linking to code paths. Additionally, it includes a test suite for the component and updates the workflow configuration to support the new functionality.

### New Component Implementation:
* [`apps/docs/components/CodeRepositoryLink/index.tsx`](diffhunk://#diff-fc01fcffacc7b6ca4fb396c3da66df70f3431fe35cf221cd35cc4d2d65516c20R1-R44): Introduced the `CodeRepositoryLink` component, which wraps Next.js `Link` to generate repository links dynamically based on the `GITHUB_REPOSITORY` environment variable. It includes support for custom `target` attributes and prevents reverse tabnabbing vulnerabilities.
* [`apps/docs/configs/urls.ts`](diffhunk://#diff-946574aefb20cc172bea575bb470dd8ca70dd6860407ae78e0cb876b5588e094R1-R4): Added the `REPOSITORY_CODE_URL` constant to construct GitHub repository URLs dynamically.

### Testing:
* [`apps/docs/components/CodeRepositoryLink/index.spec.tsx`](diffhunk://#diff-2cb1d448c7eeb019e2726dd9c3f965ec0d7b362c953309fba8e7d2111592a975R1-R42): Added unit tests for the `CodeRepositoryLink` component to verify correct rendering, href generation, and target attribute handling.

### Documentation Updates:
* Updated multiple `.mdx` files in both English and Japanese documentation to replace static links with the `<CodeRepositoryLink>` component, ensuring consistent and dynamic link generation:
  - `apps/docs/content/en/documentation/how-to-write.mdx` [[1]](diffhunk://#diff-7bd9a6d282ab1939e38125fe9bb1463bf7c2410a58ff0d666d4f91360c12269eR2) [[2]](diffhunk://#diff-7bd9a6d282ab1939e38125fe9bb1463bf7c2410a58ff0d666d4f91360c12269eR56-R93)
  - [`apps/docs/content/en/packages/default-packages/*`](diffhunk://#diff-71aa8778cb13553e8d58d28e40bad4630f3ef3ecabe309db23eee26207795448R2): Replaced static links in package documentation files, such as `browser-utils`, `eslint-plugin-sample`, `http-clients`, `node-utils`, `react-ui`, and `react-utils`. [[1]](diffhunk://#diff-71aa8778cb13553e8d58d28e40bad4630f3ef3ecabe309db23eee26207795448R2) [[2]](diffhunk://#diff-bd6a534221e62acd62c06144fd2c3c62f18c27c823c0e14207edd71c594cc240R2) [[3]](diffhunk://#diff-0938c435cbd1183d5138208fe7dfe72e76ecb2572d196ea456bfb87c81fec434R1-R2) [[4]](diffhunk://#diff-2c83ddee969ffbf3c120ab0d59be63ac1d0aee2fb5d7f841574bfe2afe8c41f7R2) [[5]](diffhunk://#diff-3f849e8f51a05c2188e634c1bbbb30dc6e5b74a75258223503e282c390aeb4bdR2) [[6]](diffhunk://#diff-dc4ef1091878c24ebc907e261b106ae5abc8b6f3593efc8ebf708cdff2d2d5b3R2)
  - Similar updates for Japanese documentation files. [[1]](diffhunk://#diff-1a474bccbf721d985ba3d79debb5d4aadb8e52a3dc0bdc93ca30db95a22d8e2bR2) [[2]](diffhunk://#diff-d1b714255e06de3d08ddeb22be08fe1c08f090a9d92837105459d6367e407ab7R2) [[3]](diffhunk://#diff-56316c6b249b6b5fde9e65e12fbc13e92a3372b75179ad0c410fb0f358ca98c3R2) [[4]](diffhunk://#diff-c8656580baa30d7c29b8986b8c2c244d1889d73b48f5e6c47898f07cc1cb081aR1-R2)

### Workflow Update:
* [`.github/workflows/publish-github-pages.yml`](diffhunk://#diff-fb39062420648092562c971c10565e97dbe28839e1c8e82d58d01ad0a30fd636L84-R85): Modified the workflow to include the `GITHUB_REPOSITORY` environment variable alongside `GISCUS_REPO`, ensuring compatibility with the new `CodeRepositoryLink` component.