### PR TITLE
`docs` 앱에서 theme 변화를 Giscus 댓글 컨테이너에 연동

### DIFF
--- a/apps/docs/containers/GisqusCommentsContainer/index.tsx
+++ b/apps/docs/containers/GisqusCommentsContainer/index.tsx
@@ -2,6 +2,7 @@
 
 import type { FC } from "react";
 import Giscus from "@giscus/react";
+import { useTheme } from "nextra-theme-docs";
 
 interface Props {
   /**
@@ -39,6 +40,9 @@ const GiscusCommentsContainer: FC<Props> = ({
   category,
   categoryId,
 }) => {
+  // Get the current Nextra theme
+  const { theme } = useTheme();
+
   return (
     <Giscus
       id="comments"
@@ -51,7 +55,7 @@ const GiscusCommentsContainer: FC<Props> = ({
       reactionsEnabled="1"
       emitMetadata="0"
       inputPosition="bottom"
-      theme="preferred_color_scheme"
+      theme={theme}
       lang="ko"
     />
   );


### PR DESCRIPTION
This pull request updates the `GiscusCommentsContainer` component to dynamically apply the current theme from the Nextra documentation theme instead of using a hardcoded value.

Theme integration:

* [`apps/docs/containers/GisqusCommentsContainer/index.tsx`](diffhunk://#diff-9e9911f02faf8e27a86876b1e06c205959380784e74d013c2a2d5151a9b23e33R5): Imported the `useTheme` hook from `nextra-theme-docs` to access the current theme.
* [`apps/docs/containers/GisqusCommentsContainer/index.tsx`](diffhunk://#diff-9e9911f02faf8e27a86876b1e06c205959380784e74d013c2a2d5151a9b23e33R43-R45): Added a `theme` variable to retrieve the current theme using `useTheme`.
* [`apps/docs/containers/GisqusCommentsContainer/index.tsx`](diffhunk://#diff-9e9911f02faf8e27a86876b1e06c205959380784e74d013c2a2d5151a9b23e33L54-R58): Updated the `theme` property in the `Giscus` component to use the dynamically retrieved `theme` instead of the hardcoded `"preferred_color_scheme"`.