### PR TITLE
`react-utils` 패키지에 `useLocalStorageListener()` 훅 추가

### DIFF
--- a/packages/react-utils/src/hooks/index.ts
+++ b/packages/react-utils/src/hooks/index.ts
@@ -1,3 +1,4 @@
 /* v8 ignore start */
 export { default as useInterval } from "./useInterval";
+export { default as useLocalStorageChangeListener } from "./useLocalStorageChangeListener";
 /* v8 ignore stop */

--- a/packages/react-utils/src/hooks/useLocalStorageChangeListener/index.spec.tsx
+++ b/packages/react-utils/src/hooks/useLocalStorageChangeListener/index.spec.tsx
@@ -1,0 +1,46 @@
+import { describe, test, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import useLocalStorageChangeListener from ".";
+
+describe("useLocalStorageChangeListener()", () => {
+  test("should register a listener for localStorage changes", () => {
+    // Mock the localStorage
+    const targetKey = "testKey";
+    const onLocalStorageChange = vi.fn();
+
+    // Render the hook
+    renderHook(() =>
+      useLocalStorageChangeListener(targetKey, onLocalStorageChange),
+    );
+
+    // Simulate a localStorage change
+    const event = new StorageEvent("storage", {
+      key: targetKey,
+      newValue: JSON.stringify({ data: "newValue" }),
+    });
+    window.dispatchEvent(event);
+
+    // Check if the callback was called with the new value
+    expect(onLocalStorageChange).toHaveBeenCalledWith(event.newValue);
+  });
+
+  test("should not call the callback for different keys", () => {
+    const targetKey = "testKey";
+    const onLocalStorageChange = vi.fn();
+
+    // Render the hook
+    renderHook(() =>
+      useLocalStorageChangeListener(targetKey, onLocalStorageChange),
+    );
+
+    // Simulate a localStorage change for a different key
+    const event = new StorageEvent("storage", {
+      key: "differentKey",
+      newValue: JSON.stringify({ data: "ignoredValue" }),
+    });
+    window.dispatchEvent(event);
+
+    // Check if the callback was not called
+    expect(onLocalStorageChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-utils/src/hooks/useLocalStorageChangeListener/index.ts
+++ b/packages/react-utils/src/hooks/useLocalStorageChangeListener/index.ts
@@ -8,7 +8,7 @@ import { useEffect } from "react";
  *
  * @example
  * ```tsx
- * const TARGET_KEY = ""myKey";
+ * const TARGET_KEY = "myKey";
  *
  * useLocalStorageChangeListener(TARGET_KEY, (newValue) => {
  *   console.log(`"${TARGET_KEY}" changed to : `, newValue);

--- a/packages/react-utils/src/hooks/useLocalStorageChangeListener/index.ts
+++ b/packages/react-utils/src/hooks/useLocalStorageChangeListener/index.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+
+/**
+ * Custom hook to register a listener for localStorage changes.
+ *
+ * @param targetKey - The key in localStorage to listen for changes.
+ * @param onLocalStorageChange - Optional callback function that will be called with the new value when the localStorage changes.
+ *
+ * @example
+ * ```tsx
+ * const TARGET_KEY = ""myKey";
+ *
+ * useLocalStorageChangeListener(TARGET_KEY, (newValue) => {
+ *   console.log(`"${TARGET_KEY}" changed to : `, newValue);
+ * });
+ * ```
+ */
+export default function useLocalStorageChangeListener(
+  targetKey: string,
+  onLocalStorageChange?: (value: StorageEvent["newValue"]) => void,
+): void {
+  useEffect(
+    function registerLocalStorageChangeListener() {
+      /**
+       * Function to handle localStorage changes.
+       *
+       * @param event - The StorageEvent object containing information about the change.
+       */
+      function handleLocalStorageChange(event: StorageEvent) {
+        // Check if the event is for the specific key we are interested in
+        const { key, newValue } = event;
+        if (key !== targetKey) return;
+
+        // Call the provided callback function with the new value
+        onLocalStorageChange?.(newValue);
+      }
+
+      // Register the localStorage change listener
+      window.addEventListener("storage", handleLocalStorageChange);
+
+      /**
+       * Cleanup function to remove the localStorage change listener.
+       */
+      return function cleanupLocalStorageChangeListener() {
+        window.removeEventListener("storage", handleLocalStorageChange);
+      };
+    },
+    [targetKey, onLocalStorageChange],
+  );
+}


### PR DESCRIPTION
This pull request introduces a new custom hook, `useLocalStorageChangeListener`, to monitor changes to specific keys in `localStorage`. The hook is added to the `react-utils` package, along with comprehensive unit tests to ensure its functionality.

### New Feature: `useLocalStorageChangeListener` Hook

* **Hook Implementation** (`packages/react-utils/src/hooks/useLocalStorageChangeListener/index.ts`): Added a custom hook, `useLocalStorageChangeListener`, which registers a listener for `localStorage` changes. It takes a `targetKey` and an optional callback function to handle changes specific to the provided key. The hook automatically cleans up the listener when the component unmounts.

* **Export Hook** (`packages/react-utils/src/hooks/index.ts`): Added `useLocalStorageChangeListener` to the list of exported hooks in the `react-utils` package.

### Unit Tests for `useLocalStorageChangeListener`

* **Test Suite** (`packages/react-utils/src/hooks/useLocalStorageChangeListener/index.spec.tsx`): Added tests to verify the behavior of `useLocalStorageChangeListener`. The tests ensure the hook correctly calls the callback for changes to the target key and ignores changes to other keys.